### PR TITLE
Feature/manage channelpoint

### DIFF
--- a/JTSA/AppDbContext.cs
+++ b/JTSA/AppDbContext.cs
@@ -15,20 +15,26 @@ namespace JTSA.Models
         public DbSet<T_GamePlaylistHeader> T_GamePlaylistHeader { get; set; }
         public DbSet<T_GamePlaylistItem> T_GamePlaylistItem { get; set; }
         public DbSet<T_ChatUser> T_ChatUser { get; set; }
-        
+        public DbSet<M_ChannelPoint> M_ChannelPoint { get; set; }
+        public DbSet<T_ChannelPointPresetHeader> T_ChannelPointPresetHeader { get; set; }
+        public DbSet<T_ChannelPointPresetItem> T_ChannelPointPresetItem { get; set; }
+
 
         /// <summary>
-        /// •¡‡ƒL[‚Ìİ’è
+        /// ï¿½ï¿½ï¿½ï¿½ï¿½Lï¿½[ï¿½Ìİ’ï¿½
         /// </summary>
         /// <param name="modelBuilder"></param>
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<T_GamePlaylistItem>()
                 .HasKey(c => new { c.GamePlayListId, c.CategoryId });
+
+            modelBuilder.Entity<T_ChannelPointPresetItem>()
+                .HasKey(c => new { c.PresetId, c.RewardId });
         }
 
         /// <summary>
-        /// DB‚Ì•¨—ƒtƒ@ƒCƒ‹ˆÊ’u‚È‚Ç‚Ìİ’è
+        /// DBï¿½Ì•ï¿½ï¿½ï¿½ï¿½tï¿½@ï¿½Cï¿½ï¿½ï¿½Ê’uï¿½È‚Ç‚Ìİ’ï¿½
         /// </summary>
         /// <param name="optionsBuilder"></param>
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -37,7 +43,7 @@ namespace JTSA.Models
             dbDirectory = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), // Roaming
                 "JTSA", "userdata");
-            Directory.CreateDirectory(dbDirectory); // ƒtƒHƒ‹ƒ_‚ª‚È‚¯‚ê‚Îì¬
+            Directory.CreateDirectory(dbDirectory); // ï¿½tï¿½Hï¿½ï¿½ï¿½_ï¿½ï¿½ï¿½È‚ï¿½ï¿½ï¿½Îì¬
             var dbPath = Path.Combine(dbDirectory, "JTSA.db");
 
             optionsBuilder.UseSqlite($"Data Source={dbPath}");

--- a/JTSA/Dao/DAO_Category.cs
+++ b/JTSA/Dao/DAO_Category.cs
@@ -67,6 +67,7 @@ namespace JTSA.Dao
                     BoxArtUrl = record.BoxArtUrl,
                     SteamUrl = record.SteamUrl,
                     SteamHeaderArtUrl = record.SteamHeaderArtUrl,
+                    ChannelPointPresetId = record.ChannelPointPresetId,
                     LastUsedDateTime = record.LastUsedDateTime,
                     CreatedDateTime = record.CreatedDateTime,
                     UpdatedDateTime = record.UpdatedDateTime

--- a/JTSA/Dao/DAO_ChannelPoint.cs
+++ b/JTSA/Dao/DAO_ChannelPoint.cs
@@ -1,0 +1,84 @@
+using JTSA.Models;
+
+namespace JTSA.Dao
+{
+    /// <summary>
+    /// チャンネルポイント報酬キャッシュ（M_ChannelPoint）のCRUD
+    /// </summary>
+    class DAO_ChannelPoint
+    {
+        #region ==================== SELECT ====================
+
+        /// <summary>
+        /// SELECT * FROM M_ChannelPoint ORDER BY Cost ASC
+        /// </summary>
+        /// <returns>検索結果</returns>
+        public static List<M_ChannelPoint> SelectAll()
+        {
+            using var db = new AppDbContext();
+
+            return db.M_ChannelPoint.OrderBy(x => x.Cost).ToList();
+        }
+
+
+        /// <summary>
+        /// プライマリキーによる単一検索
+        /// </summary>
+        /// <param name="rewardId">報酬ID</param>
+        /// <returns>検索結果</returns>
+        public static M_ChannelPoint? SelectOneById(string rewardId)
+        {
+            using var db = new AppDbContext();
+
+            return db.M_ChannelPoint.SingleOrDefault(x => x.RewardId == rewardId);
+        }
+
+        #endregion
+
+
+        #region ==================== INSERT/UPDATE ====================
+
+        /// <summary>
+        /// 報酬キャッシュを一覧の内容へ同期する。
+        /// APIから消えた報酬（Web画面で削除された等）はキャッシュからも消す。
+        /// </summary>
+        /// <param name="targetDataList">同期後の全報酬</param>
+        public static void ReplaceAll(List<M_ChannelPoint> targetDataList)
+        {
+            using var db = new AppDbContext();
+
+            var currentRecords = db.M_ChannelPoint.ToList();
+            var targetIds = targetDataList.Select(x => x.RewardId).ToHashSet();
+
+            // APIに存在しなくなった報酬を削除
+            foreach (var currentRecord in currentRecords.Where(x => !targetIds.Contains(x.RewardId)))
+            {
+                db.M_ChannelPoint.Remove(currentRecord);
+            }
+
+            foreach (var targetData in targetDataList)
+            {
+                var currentRecord = currentRecords.FirstOrDefault(x => x.RewardId == targetData.RewardId);
+
+                if (currentRecord == null)
+                {
+                    db.M_ChannelPoint.Add(targetData);
+                }
+                else
+                {
+                    currentRecord.Title = targetData.Title;
+                    currentRecord.Cost = targetData.Cost;
+                    currentRecord.ImageUrl = targetData.ImageUrl;
+                    currentRecord.IsManageable = targetData.IsManageable;
+                    currentRecord.UpdatedDateTime = targetData.UpdatedDateTime;
+                    currentRecord.LastUsedDateTime = targetData.LastUsedDateTime;
+                }
+            }
+
+            // コミット処理
+            db.SaveChanges();
+        }
+
+        #endregion
+    }
+}

--- a/JTSA/Dao/DAO_ChannelPointPreset.cs
+++ b/JTSA/Dao/DAO_ChannelPointPreset.cs
@@ -1,0 +1,200 @@
+using JTSA.Models;
+
+namespace JTSA.Dao
+{
+    /// <summary>
+    /// チャンネルポイントプリセット（ヘッダ＋アイテム）のCRUD
+    /// </summary>
+    class DAO_ChannelPointPreset
+    {
+        #region ==================== SELECT ====================
+
+        /// <summary>
+        /// プリセットヘッダの一覧取得
+        /// SELECT * FROM T_ChannelPointPresetHeader ORDER BY LastUsedDateTime DESC
+        /// </summary>
+        /// <returns>検索結果</returns>
+        public static List<T_ChannelPointPresetHeader> SelectAllHeader()
+        {
+            using var db = new AppDbContext();
+
+            return db.T_ChannelPointPresetHeader
+                     .OrderByDescending(x => x.LastUsedDateTime)
+                     .ToList();
+        }
+
+
+        /// <summary>
+        /// プリセットヘッダの単一取得
+        /// </summary>
+        /// <param name="presetId">プリセットID</param>
+        /// <returns>検索結果</returns>
+        public static T_ChannelPointPresetHeader? SelectHeaderById(long presetId)
+        {
+            using var db = new AppDbContext();
+
+            return db.T_ChannelPointPresetHeader.SingleOrDefault(x => x.PresetId == presetId);
+        }
+
+
+        /// <summary>
+        /// プリセットに紐づくアイテムの取得
+        /// </summary>
+        /// <param name="presetId">プリセットID</param>
+        /// <returns>検索結果</returns>
+        public static List<T_ChannelPointPresetItem> SelectItemsByPresetId(long presetId)
+        {
+            using var db = new AppDbContext();
+
+            return db.T_ChannelPointPresetItem
+                     .Where(x => x.PresetId == presetId)
+                     .ToList();
+        }
+
+
+        /// <summary>
+        /// プリセットごとのアイテム件数を取得する（一覧表示用）
+        /// </summary>
+        /// <returns>プリセットID → 件数</returns>
+        public static Dictionary<long, int> SelectItemCounts()
+        {
+            using var db = new AppDbContext();
+
+            return db.T_ChannelPointPresetItem
+                     .GroupBy(x => x.PresetId)
+                     .ToDictionary(x => x.Key, x => x.Count());
+        }
+
+        #endregion
+
+
+        #region ==================== INSERT/UPDATE ====================
+
+        /// <summary>
+        /// プリセットの保存（新規／上書き）。
+        ///
+        /// 全件スナップショット方式のため、アイテムは差分更新せず
+        /// 「既存を全削除 → 渡された内容を全追加」で置き換える。
+        /// （DAO_GamePlaylist.InsertUpdate は既存アイテムの削除が漏れており重複するため真似しない）
+        /// </summary>
+        /// <param name="targetHeaderData">保存するヘッダ</param>
+        /// <param name="targetItemDataList">保存するアイテム</param>
+        /// <returns>true：成功</returns>
+        public static bool InsertUpdate(
+            T_ChannelPointPresetHeader targetHeaderData,
+            List<T_ChannelPointPresetItem> targetItemDataList)
+        {
+            using var db = new AppDbContext();
+
+            // ヘッダの追加更新処理
+            var selectHeaderExeResult = db.T_ChannelPointPresetHeader
+                                          .SingleOrDefault(x => x.PresetId == targetHeaderData.PresetId);
+
+            if (selectHeaderExeResult == null)
+            {
+                db.T_ChannelPointPresetHeader.Add(targetHeaderData);
+            }
+            else
+            {
+                selectHeaderExeResult.PresetName = targetHeaderData.PresetName;
+                selectHeaderExeResult.UpdatedDateTime = targetHeaderData.UpdatedDateTime;
+                selectHeaderExeResult.LastUsedDateTime = targetHeaderData.LastUsedDateTime;
+            }
+
+            // アイテムは全置換する
+            var currentItems = db.T_ChannelPointPresetItem
+                                 .Where(x => x.PresetId == targetHeaderData.PresetId)
+                                 .ToList();
+
+            db.T_ChannelPointPresetItem.RemoveRange(currentItems);
+            db.T_ChannelPointPresetItem.AddRange(targetItemDataList);
+
+            // コミット処理
+            db.SaveChanges();
+
+            return true;
+        }
+
+
+        /// <summary>
+        /// プリセット名の変更
+        /// </summary>
+        /// <param name="presetId">プリセットID</param>
+        /// <param name="presetName">新しいプリセット名</param>
+        /// <returns>true：成功</returns>
+        public static bool UpdateName(long presetId, string presetName)
+        {
+            using var db = new AppDbContext();
+
+            var selectExeResult = db.T_ChannelPointPresetHeader.SingleOrDefault(x => x.PresetId == presetId);
+            if (selectExeResult == null) return false;
+
+            selectExeResult.PresetName = presetName;
+            selectExeResult.UpdatedDateTime = DateTime.Now;
+
+            // コミット処理
+            db.SaveChanges();
+
+            return true;
+        }
+
+
+        /// <summary>
+        /// Update：最終使用（適用したタイミングで呼ぶ）
+        /// </summary>
+        /// <param name="presetId">プリセットID</param>
+        /// <returns>true：成功</returns>
+        public static bool UpdateLastUsed(long presetId)
+        {
+            using var db = new AppDbContext();
+
+            var selectExeResult = db.T_ChannelPointPresetHeader.SingleOrDefault(x => x.PresetId == presetId);
+            if (selectExeResult == null) return false;
+
+            selectExeResult.LastUsedDateTime = DateTime.Now;
+            selectExeResult.SelectedCount++;
+
+            // コミット処理
+            db.SaveChanges();
+
+            return true;
+        }
+
+        #endregion
+
+
+        #region ==================== DELETE ====================
+
+        /// <summary>
+        /// プリセットの削除（アイテムと、カテゴリからの紐づけも同時に削除）
+        /// </summary>
+        /// <param name="presetId">プリセットID</param>
+        /// <returns>true：成功</returns>
+        public static bool Delete(long presetId)
+        {
+            using var db = new AppDbContext();
+
+            var entityHeader = db.T_ChannelPointPresetHeader.FirstOrDefault(x => x.PresetId == presetId);
+            if (entityHeader == null) return false;
+
+            var entityItems = db.T_ChannelPointPresetItem.Where(x => x.PresetId == presetId).ToList();
+
+            db.T_ChannelPointPresetItem.RemoveRange(entityItems);
+            db.T_ChannelPointPresetHeader.Remove(entityHeader);
+
+            // 存在しないプリセットを指したままにすると、カテゴリ変更のたびに適用エラーになるため外す
+            foreach (var linkedCategory in db.M_Category.Where(x => x.ChannelPointPresetId == presetId))
+            {
+                linkedCategory.ChannelPointPresetId = null;
+                linkedCategory.UpdatedDateTime = DateTime.Now;
+            }
+
+            // コミット処理
+            db.SaveChanges();
+
+            return true;
+        }
+
+        #endregion
+    }
+}

--- a/JTSA/Dao/DAO_Setting.cs
+++ b/JTSA/Dao/DAO_Setting.cs
@@ -15,6 +15,8 @@ namespace JTSA.Dao
             IsChatOverlay = 7,
             ChatOverlayPosX = 8,
             ChatOverlayPosY = 9,
+            /// <summary> チャンネルポイントのコピー時に元のタイトルへ付ける接尾辞 </summary>
+            ChannelPointCopySuffix = 10,
         }
 
 

--- a/JTSA/Forms/CategoryForm.cs
+++ b/JTSA/Forms/CategoryForm.cs
@@ -17,5 +17,11 @@ namespace JTSA.Forms
         public required String LastUsedDate { get; set; }
         public required String BoxArtUrl { get; set; }
         public required String SteamUrl { get; set; }
+
+        /// <summary>
+        /// 紐づくチャンネルポイントプリセットID。
+        /// ComboBoxのSelectedValueに使うため、未紐づけはnullではなく0で表す。
+        /// </summary>
+        public long ChannelPointPresetId { get; set; }
     }
 }

--- a/JTSA/Forms/ChannelPointPresetForm.cs
+++ b/JTSA/Forms/ChannelPointPresetForm.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel;
+
+namespace JTSA.Forms
+{
+    /// <summary>
+    /// チャンネルポイントプリセットの表示用DTO
+    /// </summary>
+    public class ChannelPointPresetForm
+    {
+        /// <summary> プリセットID </summary>
+        public long PresetId { get; set; }
+
+        /// <summary> プリセット名 </summary>
+        public string PresetName { get; set; } = "";
+
+        /// <summary> 登録されている報酬の件数 </summary>
+        public int ItemCount { get; set; }
+
+        /// <summary> 最終適用日時 </summary>
+        public string LastUsedDate { get; set; } = "";
+
+        /// <summary> 一覧に出す表示名 </summary>
+        public string DisplayText => $"{PresetName}（{ItemCount}件）";
+    }
+
+
+    /// <summary>
+    /// プリセットの中身（報酬1件分）の表示用DTO
+    /// </summary>
+    public class ChannelPointPresetItemForm : INotifyPropertyChanged
+    {
+        /// <summary> 報酬ID </summary>
+        public string RewardId { get; set; } = "";
+
+        /// <summary> 報酬名（プリセット保存時点のもの） </summary>
+        public string RewardTitle { get; set; } = "";
+
+        /// <summary>
+        /// 現在の報酬一覧に存在するか。
+        /// falseの場合、報酬が削除されているため適用時にスキップされる。
+        /// </summary>
+        public bool IsExisting { get; set; }
+
+        /// <summary> 適用時に設定する有効／無効 </summary>
+        public bool IsEnabled
+        {
+            get => isEnabled;
+            set
+            {
+                isEnabled = value;
+                OnPropertyChanged(nameof(IsEnabled));
+            }
+        }
+        private bool isEnabled;
+
+        /// <summary> 存在しない報酬であることを示す注記 </summary>
+        public string StatusText => IsExisting ? "" : "（削除済み）";
+
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void OnPropertyChanged(string name)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+}

--- a/JTSA/Forms/ChannelPointRewardForm.cs
+++ b/JTSA/Forms/ChannelPointRewardForm.cs
@@ -55,6 +55,7 @@ namespace JTSA.Forms
                 OnPropertyChanged(nameof(IsManageable));
                 OnPropertyChanged(nameof(ManageableMark));
                 OnPropertyChanged(nameof(ManageableToolTip));
+                OnPropertyChanged(nameof(CanCopy));
                 OnPropertyChanged(nameof(CopyButtonVisibility));
             }
         }
@@ -106,6 +107,9 @@ namespace JTSA.Forms
         public string ManageableToolTip => IsManageable
             ? "このアプリから操作できます。"
             : "Twitch の Web 画面（または他アプリ）から作成されたため、このアプリからは操作できません。コピーを作成してください。";
+
+        /// <summary> コピーできるのは操作不可の報酬だけ（操作可能なものは既にアプリ管理下） </summary>
+        public bool CanCopy => !IsManageable;
 
         /// <summary> コピーボタンは操作不可の報酬にだけ出す </summary>
         public Visibility CopyButtonVisibility =>

--- a/JTSA/Forms/ChannelPointRewardForm.cs
+++ b/JTSA/Forms/ChannelPointRewardForm.cs
@@ -1,0 +1,124 @@
+using System.ComponentModel;
+using System.Windows;
+
+namespace JTSA.Forms
+{
+    /// <summary>
+    /// チャンネルポイント報酬（カスタムリワード）の表示用DTO
+    /// EventSub の交換イベント用 <see cref="ChannelPointForm"/> とは別物なので注意
+    /// </summary>
+    public class ChannelPointRewardForm : INotifyPropertyChanged
+    {
+        /// <summary> 報酬ID </summary>
+        public string RewardId { get; set; } = "";
+
+        /// <summary> 報酬名 </summary>
+        public string Title { get; set; } = "";
+
+        /// <summary> 説明文 </summary>
+        public string Prompt { get; set; } = "";
+
+        /// <summary> コスト </summary>
+        public int Cost { get; set; }
+
+        /// <summary> アイコンURL（1x） </summary>
+        public string ImageUrl { get; set; } = "";
+
+        /// <summary> 背景色（#RRGGBB） </summary>
+        public string BackgroundColor { get; set; } = "";
+
+        /// <summary> ユーザー入力を要求するか </summary>
+        public bool IsUserInputRequired { get; set; }
+
+        /// <summary> 配信毎の上限（0＝無効） </summary>
+        public int MaxPerStream { get; set; }
+
+        /// <summary> 1人あたり配信毎の上限（0＝無効） </summary>
+        public int MaxPerUserPerStream { get; set; }
+
+        /// <summary> グローバルクールダウン秒（0＝無効） </summary>
+        public int GlobalCooldownSeconds { get; set; }
+
+        /// <summary> 承認キューをスキップするか </summary>
+        public bool ShouldRedemptionsSkipQueue { get; set; }
+
+        /// <summary>
+        /// このアプリ（同一client_id）から操作できるか
+        /// Twitch の Web 画面や他アプリから作成された報酬は false になる
+        /// </summary>
+        public bool IsManageable
+        {
+            get => isManageable;
+            set
+            {
+                isManageable = value;
+                OnPropertyChanged(nameof(IsManageable));
+                OnPropertyChanged(nameof(ManageableMark));
+                OnPropertyChanged(nameof(ManageableToolTip));
+                OnPropertyChanged(nameof(CopyButtonVisibility));
+            }
+        }
+        private bool isManageable;
+
+        /// <summary> 有効／無効（無効にすると視聴者の報酬一覧から消える） </summary>
+        public bool IsEnabled
+        {
+            get => isEnabled;
+            set
+            {
+                isEnabled = value;
+                OnPropertyChanged(nameof(IsEnabled));
+            }
+        }
+        private bool isEnabled;
+
+        /// <summary> 一時停止（表示されるが交換できない） </summary>
+        public bool IsPaused
+        {
+            get => isPaused;
+            set
+            {
+                isPaused = value;
+                OnPropertyChanged(nameof(IsPaused));
+            }
+        }
+        private bool isPaused;
+
+        /// <summary> 一括操作用のチェック状態（画面上のみ・APIとは無関係） </summary>
+        public bool IsSelected
+        {
+            get => isSelected;
+            set
+            {
+                isSelected = value;
+                OnPropertyChanged(nameof(IsSelected));
+            }
+        }
+        private bool isSelected;
+
+
+        // ============ 表示用の派生プロパティ ============
+
+        /// <summary> 操作可能列に出す記号 </summary>
+        public string ManageableMark => IsManageable ? "✔" : "🔒";
+
+        /// <summary> 操作可能列のツールチップ </summary>
+        public string ManageableToolTip => IsManageable
+            ? "このアプリから操作できます。"
+            : "Twitch の Web 画面（または他アプリ）から作成されたため、このアプリからは操作できません。コピーを作成してください。";
+
+        /// <summary> コピーボタンは操作不可の報酬にだけ出す </summary>
+        public Visibility CopyButtonVisibility =>
+            IsManageable ? Visibility.Collapsed : Visibility.Visible;
+
+
+        // ============ INotifyPropertyChanged ============
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        private void OnPropertyChanged(string name)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+}

--- a/JTSA/MainWindow.xaml
+++ b/JTSA/MainWindow.xaml
@@ -308,22 +308,12 @@
                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <TextBlock HorizontalAlignment="Center" x:Name="LoadPanelTextBlock" Foreground="White" FontSize="56">Loading Now...</TextBlock>
                                 <StackPanel Name="LoadSubPanel" Visibility="Visible">
-                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                        <TextBlock Text="Twithcユーザー名："
-                                            HorizontalAlignment="Center" 
-                                            Foreground="White" FontSize="20" />
-                                        <TextBox x:Name="LoadPanelUserNameTextBox" 
-                                             Width="200" Height="Auto"
-                                             Foreground="White" FontSize="20" TextAlignment="Center" 
-                                             Background="#FF4A4747" 
-                                             BorderBrush="White">
-                                        </TextBox>
-                                    </StackPanel>
-                                    <TextBlock Text="Twitchユーザー名を入力してOAuth認証ボタンをクリック" 
-                                               HorizontalAlignment="Center" 
+                                    <!-- ユーザー名はアクセストークンから特定するため入力不要 -->
+                                    <TextBlock Text="OAuth認証ボタンをクリックするとブラウザで認証画面が開きます"
+                                               HorizontalAlignment="Center"
                                                Foreground="White" FontSize="20"/>
-                                    <TextBlock Text="その後下のテキストボックスに表示される認証コードを認証画面に入力" 
-                                               HorizontalAlignment="Center" 
+                                    <TextBlock Text="その後下のテキストボックスに表示される認証コードを認証画面に入力"
+                                               HorizontalAlignment="Center"
                                                Foreground="White" FontSize="20"/>
                                     <Button DockPanel.Dock="Right" x:Name="OAuthButton" Content="OAuth認証"
                                             Width="112" Height="36" 

--- a/JTSA/MainWindow.xaml.cs
+++ b/JTSA/MainWindow.xaml.cs
@@ -622,8 +622,35 @@ namespace JTSA
             DAO_Category.UpdateLastUsed(getCategory.Id);
             CategoryPanel.ReloadCategory();
 
+            // カテゴリに紐づくチャンネルポイントプリセットを適用する（紐づけが無ければ何もしない）
+            await ApplyChannelPointPresetForCategoryAsync(getCategory.Id);
+
             AppLogPanel.ProcessEnd(GetType().Name, processLogName);
         }
+
+
+		/// <summary>
+		/// カテゴリに紐づいたチャンネルポイントプリセットを適用する。
+		/// カテゴリにプリセットが紐づいていない場合は何もしない。
+		///
+		/// カテゴリを切り替える経路（タイトル送信・プレイリストの「プレイ中」）から呼ばれる。
+		/// </summary>
+		/// <param name="categoryId">切り替え後のカテゴリID</param>
+		public async Task ApplyChannelPointPresetForCategoryAsync(string categoryId)
+		{
+			var result = await ChannelPointService.ApplyPresetForCategoryAsync(categoryId);
+
+			// 紐づけが無い場合はnullが返る。この場合は正常なので何も表示しない
+			if (result == null) return;
+
+			// 適用によって有効/無効が変わっているのでCPタブの一覧を作り直す
+			await ChannelPointPanel.ReloadChannnelPoint();
+
+			AppLogPanel.AddSwitchLog(result.IsSuccess, GetType().Name,
+				"カテゴリ連動：" + result.SummaryText,
+				"カテゴリ連動：" + result.SummaryText + "：" + result.ErrorMessage
+			);
+		}
 
 
 		/// <summary>

--- a/JTSA/MainWindow.xaml.cs
+++ b/JTSA/MainWindow.xaml.cs
@@ -218,19 +218,16 @@ namespace JTSA
 				return;
             }
 
-			// ユーザー名取得確認
-			M_Setting? settingUserName = DAO_Setting.SelectOneById(DAO_Setting.SettingName.UserName) ?? null;
-			if (settingUserName == null || string.IsNullOrEmpty(settingUserName.Value))
+			// リフレッシュトークン取得確認
+			// ユーザー名はアクセストークンから特定できるため、保存済みトークンの有無だけを見る
+			M_Setting? settingRefreshToken = DAO_Setting.SelectOneById(DAO_Setting.SettingName.RefreshToken) ?? null;
+			if (settingRefreshToken == null || string.IsNullOrEmpty(settingRefreshToken.Value))
             {
-                UserName_TextBox.Text = "NG";
-                AppLogPanel.Error(GetType().Name, appLogProcessName + "：ユーザー名未設定");
+                AccessToken_TextBlock.Text = "NG";
+                AppLogPanel.Error(GetType().Name, appLogProcessName + "：未認証（OAuth認証が必要）");
                 LoadSubPanel.Visibility = Visibility.Visible;
 				return;
 			}
-
-            // メモリに登録
-            JTSAHelper.LoginName = settingUserName.Value;
-			UserName_TextBox.Text = JTSAHelper.LoginName;
 
 			// リフレッシュトークンからアクセストークンを再取得
 			string accessToken = await ResetAccessTokenAsync();
@@ -248,40 +245,61 @@ namespace JTSA
 
             AppLogPanel.ProcessEnd(GetType().Name, appLogProcessName);
 
-			// 配信者IDの取得
-            var streamerInfo = await TwitchHelper.GetBroadcasterIdAsync(JTSAHelper.LoginName);
-            if (streamerInfo == null)
-            {
-                AppLogPanel.Error(GetType().Name, "配信者情報未取得");
-                return;
-            }
+			// 認証後の初期化（OAuth認証直後と共通）
+			await InitializeAfterAuthAsync();
+        }
+
+
+		/// <summary>
+		/// アクセストークン取得後の初期化処理。
+		/// 起動時（リフレッシュトークン経由）とOAuth認証直後の両方から呼ばれる共通処理。
+		///
+		/// 以前はこの処理が起動時シーケンスにしか無く、OAuth認証直後は
+		/// BroadcasterIdもIgdbServiceも未設定のままStreamerDataSet()を呼んで落ちていた。
+		/// </summary>
+		private async Task InitializeAfterAuthAsync()
+		{
+			var appLogProcessName = AppLogPanel.ProcessStart(GetType().Name, "アプリ初期化処理");
+
+			// 配信者情報の取得（アクセストークンの持ち主＝配信者本人）
+			var streamerInfo = await TwitchHelper.GetAuthenticatedUserAsync();
+			if (streamerInfo == null)
+			{
+				BroadcasterId_TextBlock.Text = "NG";
+				AppLogPanel.Error(GetType().Name, "配信者情報未取得");
+				LoadSubPanel.Visibility = Visibility.Visible;
+				return;
+			}
 
 			// メモリに登録
-            TwitchHelper.BroadcasterId = streamerInfo.UserId;
-            BroadcasterId_TextBlock.Text = "OK!";
+			TwitchHelper.BroadcasterId = streamerInfo.UserId;
+			BroadcasterId_TextBlock.Text = "OK!";
 
-            appLogProcessName = AppLogPanel.ProcessStart(GetType().Name, "アプリ初期化処理");
+			JTSAHelper.LoginName = streamerInfo.Login;
+			UserName_TextBox.Text = JTSAHelper.LoginName;
 
+			// 表示・Twitchダッシュボードのリンク用に保存しておく
+			DAO_Setting.InsertUpdate(DAO_Setting.SettingName.UserName, JTSAHelper.LoginName);
 
-            IgdbService.Initialize(new HttpClient(), TwitchHelper.ClientID, TwitchHelper.AccessToken);
+			IgdbService.Initialize(new HttpClient(), TwitchHelper.ClientID, TwitchHelper.AccessToken);
 
+			// アクセストークンの確認を持って起動時設定を完了
+			await StreamerDataSet();
 
-            // アクセストークンの確認を持って起動時設定を完了
-            await StreamerDataSet();
-
-            // 各パネルの初期化処理
-            ChatPanel.Initialize();
+			// 各パネルの初期化処理
+			ChatPanel.Initialize();
 			CategoryPanel.Initialize();
 			await ChannelPointPanel.Initialize();
 
-            PlayingGamePanel.ReloadPlaylistHeader();
-            PlayingGamePanel.ReloadGamePlaylistItem();
+			PlayingGamePanel.ReloadPlaylistHeader();
+			PlayingGamePanel.ReloadGamePlaylistItem();
 
-            // ロード画面を非表示
-            LoadScreen.Visibility = Visibility.Collapsed;
+			// ロード画面を非表示
+			LoadScreen.Visibility = Visibility.Collapsed;
+			LoadSubPanel.Visibility = Visibility.Collapsed;
 
-            AppLogPanel.ProcessEnd(GetType().Name, appLogProcessName);
-        }
+			AppLogPanel.ProcessEnd(GetType().Name, appLogProcessName);
+		}
 
 
         /// <summary>
@@ -332,6 +350,12 @@ namespace JTSA
 
             // タイトル取得処理
             var streamInfo = await TwitchHelper.GetTwitchStreamInfo(TwitchHelper.BroadcasterId);
+            if (streamInfo == null)
+            {
+                AppLogPanel.Error(GetType().Name, "配信情報の取得に失敗しました");
+                return;
+            }
+
             CurrentTitleText = streamInfo.title;
 
             TitleEditTextBox.Text = CurrentTitleTextBlock.Text;
@@ -340,14 +364,33 @@ namespace JTSA
 
 			if(dbCategoryData == null)
 			{
-                // カテゴリ名取得処理
+                // DBに未登録のカテゴリなので、Twitch/IGDBから取得して組み立てる
                 var category = await TwitchHelper.GetCategoryByGameId(streamInfo.gameId);
+                if (category == null)
+                {
+                    // カテゴリ未設定で配信している場合などはここに来る。タイトルだけ反映して終了する
+                    AppLogPanel.Error(GetType().Name, "カテゴリ情報の取得に失敗しました");
+
+                    CurrentTitleText = TitleEditTextBox.Text;
+                    ReloadTitleText();
+                    TitleTagSidePanel.ReloadTitleTag();
+
+                    AppLogPanel.ProcessEnd(GetType().Name, appLogProcessName);
+                    return;
+                }
+
 				var steamUrl = await IgdbService.GetSteamUrlsAsync(category.Id);
 
-                dbCategoryData.CategoryId = category.Id;
-				dbCategoryData.DisplayName = category.Name;
-				dbCategoryData.SteamUrl = steamUrl[0] ?? string.Empty;
-				dbCategoryData.BoxArtUrl = category.BoxArtUrl;
+                dbCategoryData = new M_Category
+                {
+                    CategoryId = category.Id,
+                    DisplayName = category.Name,
+                    SteamUrl = steamUrl?.FirstOrDefault() ?? string.Empty,
+                    BoxArtUrl = category.BoxArtUrl,
+                    LastUsedDateTime = DateTime.Now,
+                    CreatedDateTime = DateTime.Now,
+                    UpdatedDateTime = DateTime.Now
+                };
             }
 
             CurrentTitleText = TitleEditTextBox.Text;
@@ -375,41 +418,46 @@ namespace JTSA
 		/// <param name="e"></param>
 		private async void OAuthButton_Click(object sender, RoutedEventArgs e)
 		{
+			var appLogProcessName = AppLogPanel.ProcessStart(GetType().Name, "OAuth認証");
+
 			// Loading画面表示
 			LoadScreen.Visibility = Visibility.Visible;
-
-            JTSAHelper.LoginName = LoadPanelUserNameTextBox.Text.Trim();
-			UserName_TextBox.Text = JTSAHelper.LoginName;
+			LoadSubPanel.Visibility = Visibility.Visible;
 
 			var deviceCodeResponse = await TwitchHelper.RequestDeviceCodeAsync();
+			if (deviceCodeResponse == null)
+			{
+				AccessToken_TextBlock.Text = "NG";
+				AppLogPanel.Error(GetType().Name, "デバイスコードの取得に失敗しました");
+				return;
+			}
 
 			// 認証URLとユーザーコードをユーザーに表示
 			LoadPanelSubTextBox.Text = deviceCodeResponse.user_code;
 
-			LoadSubPanel.Visibility = Visibility.Visible;
-
 			// 認証ページを自動で開く
-			Process.Start(new ProcessStartInfo(deviceCodeResponse.verification_uri + $"user_code={JTSAHelper.LoginName}") { UseShellExecute = true });
+			// verification_uri_complete はユーザーコードを埋め込み済みのURL
+			var verificationUrl = string.IsNullOrEmpty(deviceCodeResponse.verification_uri_complete)
+				? deviceCodeResponse.verification_uri
+				: deviceCodeResponse.verification_uri_complete;
+
+			Process.Start(new ProcessStartInfo(verificationUrl) { UseShellExecute = true });
 
 			// アクセストークン取得
 			var accessTokenResponse = await TwitchHelper.PollDeviceTokenAsync(deviceCodeResponse.device_code, deviceCodeResponse.interval, deviceCodeResponse.expires_in);
 
-            if (accessTokenResponse != null)
-			{
-				TwitchHelper.AccessToken = accessTokenResponse.accessToken;
-				AccessToken_TextBlock.Text = "OK!";
-			}
-			else
+			if (accessTokenResponse == null)
 			{
 				AccessToken_TextBlock.Text = "NG";
+				AppLogPanel.Error(GetType().Name, "アクセストークンの取得に失敗しました");
+				return;
 			}
 
-			// --- 設定情報保存処理 ---
-			DAO_Setting.InsertUpdate(
-				DAO_Setting.SettingName.UserName,
-				JTSAHelper.LoginName
-			);
+			TwitchHelper.AccessToken = accessTokenResponse.accessToken;
+			AccessToken_TextBlock.Text = "OK!";
 
+			// --- 設定情報保存処理 ---
+			// ユーザー名はこの後 InitializeAfterAuthAsync がアクセストークンから特定して保存する
 			DAO_Setting.InsertUpdate(
 				DAO_Setting.SettingName.RefreshToken,
 				accessTokenResponse.refreshToken
@@ -420,9 +468,10 @@ namespace JTSA
 				accessTokenResponse.expiresIn.ToString()
 			);
 
-			await StreamerDataSet();
+			AppLogPanel.ProcessEnd(GetType().Name, appLogProcessName);
 
-			LoadScreen.Visibility = Visibility.Collapsed;
+			// 認証後の初期化（起動時と共通）
+			await InitializeAfterAuthAsync();
 		}
 
 		#endregion

--- a/JTSA/MainWindow.xaml.cs
+++ b/JTSA/MainWindow.xaml.cs
@@ -272,6 +272,7 @@ namespace JTSA
             // 各パネルの初期化処理
             ChatPanel.Initialize();
 			CategoryPanel.Initialize();
+			await ChannelPointPanel.Initialize();
 
             PlayingGamePanel.ReloadPlaylistHeader();
             PlayingGamePanel.ReloadGamePlaylistItem();

--- a/JTSA/Migrations/20260809075615_channel_point_preset.Designer.cs
+++ b/JTSA/Migrations/20260809075615_channel_point_preset.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using JTSA.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace JTSA.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260809075615_channel_point_preset")]
+    partial class channel_point_preset
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.9");

--- a/JTSA/Migrations/20260809075615_channel_point_preset.cs
+++ b/JTSA/Migrations/20260809075615_channel_point_preset.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JTSA.Migrations
+{
+    /// <inheritdoc />
+    public partial class channel_point_preset : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "ChannelPointPresetId",
+                table: "M_Category",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "M_ChannelPoint",
+                columns: table => new
+                {
+                    RewardId = table.Column<string>(type: "TEXT", nullable: false),
+                    Title = table.Column<string>(type: "TEXT", nullable: false),
+                    Cost = table.Column<int>(type: "INTEGER", nullable: false),
+                    ImageUrl = table.Column<string>(type: "TEXT", nullable: true),
+                    IsManageable = table.Column<bool>(type: "INTEGER", nullable: false),
+                    LastUsedDateTime = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    CreatedDateTime = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedDateTime = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_M_ChannelPoint", x => x.RewardId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "T_ChannelPointPresetHeader",
+                columns: table => new
+                {
+                    PresetId = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    PresetName = table.Column<string>(type: "TEXT", nullable: false),
+                    LastUsedDateTime = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    CreatedDateTime = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedDateTime = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    SelectedCount = table.Column<int>(type: "INTEGER", nullable: false),
+                    SortNumber = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_T_ChannelPointPresetHeader", x => x.PresetId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "T_ChannelPointPresetItem",
+                columns: table => new
+                {
+                    PresetId = table.Column<long>(type: "INTEGER", nullable: false),
+                    RewardId = table.Column<string>(type: "TEXT", nullable: false),
+                    IsEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    RewardTitle = table.Column<string>(type: "TEXT", nullable: false),
+                    LastUsedDateTime = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    CreatedDateTime = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedDateTime = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    SelectedCount = table.Column<int>(type: "INTEGER", nullable: false),
+                    SortNumber = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_T_ChannelPointPresetItem", x => new { x.PresetId, x.RewardId });
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "M_ChannelPoint");
+
+            migrationBuilder.DropTable(
+                name: "T_ChannelPointPresetHeader");
+
+            migrationBuilder.DropTable(
+                name: "T_ChannelPointPresetItem");
+
+            migrationBuilder.DropColumn(
+                name: "ChannelPointPresetId",
+                table: "M_Category");
+        }
+    }
+}

--- a/JTSA/Models/M_Category.cs
+++ b/JTSA/Models/M_Category.cs
@@ -13,4 +13,10 @@ public class M_Category : DBBase
     public string? SteamUrl { get; set; }
 
     public string? SteamHeaderArtUrl { get; set; }
+
+    /// <summary>
+    /// このカテゴリに紐づくチャンネルポイントプリセットID。
+    /// null（未紐づけ）の場合はカテゴリを切り替えてもプリセットを適用しない。
+    /// </summary>
+    public long? ChannelPointPresetId { get; set; }
 }

--- a/JTSA/Models/M_ChannelPoint.cs
+++ b/JTSA/Models/M_ChannelPoint.cs
@@ -1,0 +1,26 @@
+using JTSA.Models;
+using System.ComponentModel.DataAnnotations;
+
+/// <summary>
+/// チャンネルポイント報酬のキャッシュ。
+/// プリセット編集画面が Twitch API を叩かずに報酬名を表示できるようにするために持つ。
+/// 一覧取得のたびに上書きされる。
+/// </summary>
+public class M_ChannelPoint : DBBase
+{
+    /// <summary> 報酬ID（TwitchのカスタムリワードID） </summary>
+    [Key]
+    public required string RewardId { get; set; }
+
+    /// <summary> 報酬名 </summary>
+    public required string Title { get; set; }
+
+    /// <summary> コスト </summary>
+    public int Cost { get; set; }
+
+    /// <summary> アイコンURL（1x） </summary>
+    public string? ImageUrl { get; set; }
+
+    /// <summary> このアプリ（同一client_id）から操作できるか </summary>
+    public bool IsManageable { get; set; }
+}

--- a/JTSA/Models/T_ChannelPointPresetHeader.cs
+++ b/JTSA/Models/T_ChannelPointPresetHeader.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace JTSA.Models
+{
+    /// <summary>
+    /// チャンネルポイントのプリセット（報酬ON/OFFの組み合わせ）のヘッダ
+    /// </summary>
+    public class T_ChannelPointPresetHeader : DBBaseTransaction
+    {
+        /// <summary> プリセットID（T_GamePlaylistHeaderと同じくUnixミリ秒で採番する） </summary>
+        [Key]
+        public long PresetId { get; set; }
+
+        /// <summary> プリセット名 </summary>
+        public required string PresetName { get; set; }
+    }
+}

--- a/JTSA/Models/T_ChannelPointPresetItem.cs
+++ b/JTSA/Models/T_ChannelPointPresetItem.cs
@@ -1,0 +1,23 @@
+namespace JTSA.Models
+{
+    /// <summary>
+    /// プリセットの中身。保存時点の「操作可能な全報酬」の有効／無効を1件1レコードで保持する。
+    ///
+    /// 差分方式ではなく全件スナップショット方式にしているのは、
+    /// 適用すれば必ず狙った状態が再現され、指定漏れが起きないようにするため。
+    /// </summary>
+    public class T_ChannelPointPresetItem : DBBaseTransaction
+    {
+        /// <summary> プリセットID [複合キー] </summary>
+        public required long PresetId { get; set; }
+
+        /// <summary> 報酬ID [複合キー] </summary>
+        public required string RewardId { get; set; }
+
+        /// <summary> 適用時に設定する有効／無効 </summary>
+        public bool IsEnabled { get; set; }
+
+        /// <summary> 保存時点の報酬名。報酬が削除された後もプリセットの内容を表示できるようにするため </summary>
+        public required string RewardTitle { get; set; }
+    }
+}

--- a/JTSA/Panels/CategoryPanel.xaml
+++ b/JTSA/Panels/CategoryPanel.xaml
@@ -62,7 +62,8 @@
                                             <Grid Margin="0" Height="Auto" Grid.Column="2" >
                                                 <Grid.RowDefinitions>
                                                     <RowDefinition Height="Auto"/>
-                                                    <RowDefinition Height="*"/>
+                                                    <RowDefinition Height="Auto"/>
+                                                    <RowDefinition Height="Auto"/>
                                                 </Grid.RowDefinitions>
                                                 <TextBlock Grid.Row="0" Text="{Binding DisplayName}" Width="Auto" Foreground="White" FontSize="16" TextWrapping="Wrap"></TextBlock>
 
@@ -75,9 +76,21 @@
                                                     <Label Grid.Column="0" Margin="0" VerticalAlignment="Bottom" Foreground="White" FontSize="10">SteamURL：</Label>
                                                     <TextBox Grid.Column="1" Width="Auto" Name="SteamURLTextBox" Text="{Binding SteamUrl}"></TextBox>
                                                     <Button
-                                                        Grid.Column="2" Grid.Row="1"  Content="URL更新" Width="64" Height="20" Margin="8, 0, 0, 0" VerticalAlignment="Center" 
+                                                        Grid.Column="2" Grid.Row="1"  Content="URL更新" Width="64" Height="20" Margin="8, 0, 0, 0" VerticalAlignment="Center"
                                                         Click="SteamURLUpdateButton_Click"/>
                                                 </Grid>
+
+                                                <!-- カテゴリに紐づくチャンネルポイントプリセット（未設定なら切り替えを行わない） -->
+                                                <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0, 4, 0, 0">
+                                                    <Label Margin="0" VerticalAlignment="Center" Foreground="White" FontSize="10">CPプリセット：</Label>
+                                                    <ComboBox Width="180" Height="20" VerticalAlignment="Center"
+                                                              ItemsSource="{Binding DataContext.ChannelPointPresetFormList, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                              DisplayMemberPath="PresetName"
+                                                              SelectedValuePath="PresetId"
+                                                              SelectedValue="{Binding ChannelPointPresetId, Mode=TwoWay}"
+                                                              SelectionChanged="CategoryPresetComboBox_SelectionChanged"
+                                                              ToolTip="このカテゴリを設定したときに自動適用するプリセット。「（自動適用しない）」を選ぶと何も変更しません。"/>
+                                                </StackPanel>
                                             </Grid>
                                         </Grid>
                                         <Grid Margin="0" Height="Auto">

--- a/JTSA/Panels/CategoryPanel.xaml.cs
+++ b/JTSA/Panels/CategoryPanel.xaml.cs
@@ -24,6 +24,12 @@ namespace JTSA.Panels
         /// <summary>  </summary>
         public ObservableCollection<CategoryForm> CategoryFormList { get; } = new();
 
+        /// <summary> カテゴリに紐づけられるチャンネルポイントプリセットの選択肢 </summary>
+        public ObservableCollection<ChannelPointPresetForm> ChannelPointPresetFormList { get; } = new();
+
+        /// <summary> 「紐づけなし」を表すプリセットID（ComboBoxはnullを扱いにくいため0を使う） </summary>
+        private const long PRESET_ID_NONE = 0;
+
         /// <summary>
         /// コンストラクタ
         /// </summary>
@@ -85,6 +91,9 @@ namespace JTSA.Panels
             using var db = new AppDbContext();
             CategoryFormList.Clear();
 
+            // プリセットの選択肢を先に用意する（カテゴリ行のComboBoxが参照するため）
+            ReloadChannelPointPreset();
+
             // データの取得
             var records = DAO_Category.SelectAllOrderbyLastUser();
 
@@ -97,12 +106,73 @@ namespace JTSA.Panels
                     DisplayName = item.DisplayName,
                     BoxArtUrl = item.BoxArtUrl,
                     SteamUrl = item.SteamUrl ?? "",
+                    ChannelPointPresetId = item.ChannelPointPresetId ?? PRESET_ID_NONE,
                     LastUsedDate = item.LastUsedDateTime.ToString("yyyy/MM/dd hh:mm")
                 });
             }
 
             mainWindow.StatusTextBlock.Text = "カテゴリリストを読込";
             mainWindow.StatusTextBlock.Foreground = System.Windows.Media.Brushes.LightGreen;
+        }
+
+
+        /// <summary>
+        /// カテゴリに紐づけるプリセットの選択肢を読み込み直す。
+        /// CPタブでプリセットを増減した後にも呼ばれる。
+        /// </summary>
+        public void ReloadChannelPointPreset()
+        {
+            ChannelPointPresetFormList.Clear();
+
+            // 「紐づけなし」を先頭に置く。これを選ぶとカテゴリ変更時に何も適用しない
+            ChannelPointPresetFormList.Add(new ChannelPointPresetForm
+            {
+                PresetId = PRESET_ID_NONE,
+                PresetName = "（自動適用しない）"
+            });
+
+            foreach (var header in DAO_ChannelPointPreset.SelectAllHeader())
+            {
+                ChannelPointPresetFormList.Add(new ChannelPointPresetForm
+                {
+                    PresetId = header.PresetId,
+                    PresetName = header.PresetName
+                });
+            }
+        }
+
+
+        /// <summary>
+        /// カテゴリ行のプリセット選択が変わったとき：紐づけを保存する
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void CategoryPresetComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if ((sender as ComboBox)?.DataContext is not CategoryForm item) return;
+
+            var updateCategory = DAO_Category.SelectOneById(item.CategoryId);
+            if (updateCategory == null) return;
+
+            var selectedPresetId = item.ChannelPointPresetId == PRESET_ID_NONE
+                ? (long?)null
+                : item.ChannelPointPresetId;
+
+            // 一覧の再読込による初期バインドでもこのイベントは発火するため、
+            // 実際に値が変わったときだけ書き込む
+            if (updateCategory.ChannelPointPresetId == selectedPresetId) return;
+
+            updateCategory.ChannelPointPresetId = selectedPresetId;
+
+            var isSuccess = DAO_Category.Update(updateCategory);
+
+            var presetName = ChannelPointPresetFormList
+                .FirstOrDefault(x => x.PresetId == item.ChannelPointPresetId)?.PresetName ?? "";
+
+            mainWindow.AppLogPanel.AddSwitchLog(isSuccess, GetType().Name,
+                $"CPプリセット紐づけ 「 {item.DisplayName} 」→「 {presetName} 」",
+                $"CPプリセット紐づけ失敗 「 {item.DisplayName} 」"
+            );
         }
 
 

--- a/JTSA/Panels/ChannelPointPanel.xaml
+++ b/JTSA/Panels/ChannelPointPanel.xaml
@@ -18,8 +18,14 @@
         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="5">
             <Button x:Name="ReloadButton" Content="更新" Width="70" Margin="0,0,8,0"
                     Click="ReloadButton_Click" />
-            <Button x:Name="CreateRewardButton" Content="新規作成" Width="90"
+            <Button x:Name="CreateRewardButton" Content="新規作成" Width="90" Margin="0,0,8,0"
                     Click="CreateRewardButton_Click" />
+            <Button x:Name="CopySelectedButton" Content="選択をコピー" Width="110" Margin="0,0,8,0"
+                    Click="CopySelectedButton_Click"
+                    ToolTip="チェックした「操作不可（🔒）」の報酬を、このアプリから操作できる報酬としてコピーします。" />
+            <Button x:Name="OpenTwitchRewardPageButton" Content="Twitchの報酬設定を開く" Width="160"
+                    Click="OpenTwitchRewardPageButton_Click"
+                    ToolTip="コピー元の報酬の削除や画像設定は Twitch の Web 画面から行います。" />
         </StackPanel>
 
         <!-- 2行目: ステータス表示 -->
@@ -57,6 +63,17 @@
             </ListView.Resources>
             <ListView.View>
                 <GridView>
+                    <GridViewColumn Header="選択" Width="40">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <!-- 一括コピー用。コピーできるのは操作不可の報酬だけ -->
+                                <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                          IsEnabled="{Binding CanCopy}"
+                                          HorizontalAlignment="Center" />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+
                     <GridViewColumn Header="操作可能" Width="60">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
@@ -105,6 +122,19 @@
                     <GridViewColumn Header="タイトル" Width="200" DisplayMemberBinding="{Binding Title}" />
 
                     <GridViewColumn Header="コスト" Width="80" DisplayMemberBinding="{Binding Cost}" />
+
+                    <GridViewColumn Header="コピー" Width="70">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <!-- 操作不可の報酬にだけ出す -->
+                                <Button Content="コピー" Width="60"
+                                        Visibility="{Binding CopyButtonVisibility}"
+                                        Tag="{Binding}"
+                                        Click="CopyRewardButton_Click"
+                                        ToolTip="この報酬と同じ設定で、このアプリから操作できる報酬を作成します。" />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
                 </GridView>
             </ListView.View>
         </ListView>

--- a/JTSA/Panels/ChannelPointPanel.xaml
+++ b/JTSA/Panels/ChannelPointPanel.xaml
@@ -9,6 +9,7 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/> <!-- プリセット -->
             <RowDefinition Height="Auto"/> <!-- ステータス -->
             <RowDefinition Height="Auto"/> <!-- 入力フォーム用 -->
             <RowDefinition Height="*"/>
@@ -28,12 +29,68 @@
                     ToolTip="コピー元の報酬の削除や画像設定は Twitch の Web 画面から行います。" />
         </StackPanel>
 
-        <!-- 2行目: ステータス表示 -->
-        <TextBlock Grid.Row="1" x:Name="ChannelPointGetStatus" Foreground="White"
+        <!-- 2行目: プリセット -->
+        <Border Grid.Row="1" Margin="5,0,5,5" Background="#333" CornerRadius="4" Padding="8">
+            <StackPanel>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="プリセット:" Foreground="White" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <ComboBox x:Name="PresetComboBox" Width="220" Margin="0,0,8,0"
+                              ItemsSource="{Binding ChannelPointPresetFormList}"
+                              DisplayMemberPath="DisplayText"
+                              SelectionChanged="PresetComboBox_SelectionChanged"/>
+                    <Button x:Name="ApplyPresetButton" Content="適用" Width="70" Margin="0,0,8,0"
+                            Click="ApplyPresetButton_Click"
+                            ToolTip="選択したプリセットの状態に、報酬の有効/無効をまとめて切り替えます。"/>
+                    <Button x:Name="OverwritePresetButton" Content="上書き保存" Width="90" Margin="0,0,8,0"
+                            Click="OverwritePresetButton_Click"
+                            ToolTip="今の一覧の有効/無効で、選択中のプリセットを上書きします。"/>
+                    <Button x:Name="DeletePresetButton" Content="削除" Width="60"
+                            Click="DeletePresetButton_Click"/>
+                </StackPanel>
+
+                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                    <TextBlock Text="名前:" Foreground="White" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                    <TextBox x:Name="PresetNameTextBox" Width="220" Margin="0,0,8,0"
+                             ToolTip="新規保存する名前、または選択中プリセットの新しい名前を入力します。"/>
+                    <Button x:Name="SavePresetButton" Content="この名前で新規保存" Width="150" Margin="0,0,8,0"
+                            Click="SavePresetButton_Click"
+                            ToolTip="今の一覧の有効/無効を、新しいプリセットとして保存します。"/>
+                    <Button x:Name="RenamePresetButton" Content="名前変更" Width="80"
+                            Click="RenamePresetButton_Click"
+                            ToolTip="選択中のプリセットの名前を、入力した名前へ変更します。"/>
+                </StackPanel>
+
+                <!-- 選択中プリセットの内訳 -->
+                <TextBlock x:Name="PresetDetailStatus" Foreground="#FFBBBBBB" Margin="0,6,0,0"
+                           TextWrapping="Wrap"
+                           Text="プリセットを選択すると内容が表示されます。"/>
+                <ListView x:Name="PresetItemListView" Height="110" Margin="0,4,0,0"
+                          ItemsSource="{Binding ChannelPointPresetItemFormList}"
+                          Visibility="Collapsed">
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn Header="有効" Width="45">
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <!-- ここは表示専用。変更は一覧側で行って「上書き保存」する -->
+                                        <CheckBox IsChecked="{Binding IsEnabled, Mode=OneWay}" IsHitTestVisible="False"/>
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+                            <GridViewColumn Header="報酬名" Width="260" DisplayMemberBinding="{Binding RewardTitle}"/>
+                            <GridViewColumn Header="状態" Width="90" DisplayMemberBinding="{Binding StatusText}"/>
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+            </StackPanel>
+        </Border>
+
+        <!-- 3行目: ステータス表示 -->
+        <TextBlock Grid.Row="2" x:Name="ChannelPointGetStatus" Foreground="White"
                    Margin="5,0,5,5" TextWrapping="Wrap" />
 
-        <!-- 3行目: 入力フォーム（初期は非表示） -->
-        <Border Grid.Row="2" Margin="5" Background="#222" CornerRadius="4" Padding="8"
+        <!-- 4行目: 入力フォーム（初期は非表示） -->
+        <Border Grid.Row="3" Margin="5" Background="#222" CornerRadius="4" Padding="8"
                 x:Name="RewardFormPanel" Visibility="Collapsed">
             <StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
@@ -53,8 +110,8 @@
             </StackPanel>
         </Border>
 
-        <!-- 4行目: リスト -->
-        <ListView x:Name="ChannelPointListView" Grid.Row="3" Margin="5"
+        <!-- 5行目: リスト -->
+        <ListView x:Name="ChannelPointListView" Grid.Row="4" Margin="5"
                   ItemsSource="{Binding ChannelPointRewardFormList}">
             <ListView.Resources>
                 <Style TargetType="{x:Type GridViewColumnHeader}">

--- a/JTSA/Panels/ChannelPointPanel.xaml
+++ b/JTSA/Panels/ChannelPointPanel.xaml
@@ -1,6 +1,6 @@
-﻿<UserControl x:Class="JTSA.Panels.ChannelPointPanel"
+<UserControl x:Class="JTSA.Panels.ChannelPointPanel"
             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
             mc:Ignorable="d"
@@ -9,21 +9,27 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/> <!-- ステータス -->
             <RowDefinition Height="Auto"/> <!-- 入力フォーム用 -->
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <!-- 1行目: ステータス＋新規作成ボタン -->
-        <DockPanel Grid.Row="0" Margin="5">
-            <TextBlock x:Name="ChannelPointGetStatus" Foreground="White" VerticalAlignment="Center" />
-            <Button x:Name="CreateRewardButton" Content="新規作成" Width="90" Margin="8,0,0,0"
-                    HorizontalAlignment="Right" Click="CreateRewardButton_Click" />
-        </DockPanel>
+        <!-- 1行目: ツールバー -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="5">
+            <Button x:Name="ReloadButton" Content="更新" Width="70" Margin="0,0,8,0"
+                    Click="ReloadButton_Click" />
+            <Button x:Name="CreateRewardButton" Content="新規作成" Width="90"
+                    Click="CreateRewardButton_Click" />
+        </StackPanel>
 
-        <!-- 2行目: 入力フォーム（初期は非表示） -->
-        <Border Grid.Row="1" Margin="5" Background="#222" CornerRadius="4" Padding="8"
+        <!-- 2行目: ステータス表示 -->
+        <TextBlock Grid.Row="1" x:Name="ChannelPointGetStatus" Foreground="White"
+                   Margin="5,0,5,5" TextWrapping="Wrap" />
+
+        <!-- 3行目: 入力フォーム（初期は非表示） -->
+        <Border Grid.Row="2" Margin="5" Background="#222" CornerRadius="4" Padding="8"
                 x:Name="RewardFormPanel" Visibility="Collapsed">
-            <StackPanel Tag="False">
+            <StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
                     <TextBlock Text="名前:" Width="60" Foreground="White" VerticalAlignment="Center"/>
                     <TextBox x:Name="RewardNameTextBox" Width="200"/>
@@ -32,10 +38,8 @@
                     <TextBlock Text="コスト:" Width="60" Foreground="White" VerticalAlignment="Center"/>
                     <TextBox x:Name="RewardCostTextBox" Width="100"/>
                 </StackPanel>
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                    <TextBlock Text="画像:" Width="60" Foreground="White" VerticalAlignment="Center"/>
-                    <TextBox x:Name="RewardImageUrlTextBox" IsEnabled="False" Width="300"/>
-                </StackPanel>
+                <TextBlock Foreground="#FFBBBBBB" TextWrapping="Wrap" Margin="0,0,0,8"
+                           Text="※ 画像は Twitch API では設定できません。作成後に Twitch の Web 画面から設定してください。"/>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                     <Button Content="作成" Width="80" Margin="0,0,8,0" Click="CreateRewardSubmitButton_Click"/>
                     <Button Content="キャンセル" Width="80" Click="CreateRewardCancelButton_Click"/>
@@ -43,8 +47,9 @@
             </StackPanel>
         </Border>
 
-        <!-- 3行目: リスト -->
-        <ListView x:Name="ChannelPointListView" Grid.Row="2" Margin="5">
+        <!-- 4行目: リスト -->
+        <ListView x:Name="ChannelPointListView" Grid.Row="3" Margin="5"
+                  ItemsSource="{Binding ChannelPointRewardFormList}">
             <ListView.Resources>
                 <Style TargetType="{x:Type GridViewColumnHeader}">
                     <EventSetter Event="Click" Handler="GridViewColumnHeader_Click"/>
@@ -52,34 +57,46 @@
             </ListView.Resources>
             <ListView.View>
                 <GridView>
-                    <GridViewColumn Header="操作可能">
+                    <GridViewColumn Header="操作可能" Width="60">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
-                            </DataTemplate>
-                        </GridViewColumn.CellTemplate>
-                    </GridViewColumn>
-                    <GridViewColumn Header="画像" Width="50">
-                        <GridViewColumn.CellTemplate>
-                            <DataTemplate>
-                                <Image Source="{Binding Image.Url1x}" Height="28" />
+                                <TextBlock Text="{Binding ManageableMark}"
+                                           ToolTip="{Binding ManageableToolTip}"
+                                           HorizontalAlignment="Center"
+                                           FontSize="14" />
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
 
-                    <GridViewColumn Header="有効">
+                    <GridViewColumn Header="画像" Width="50">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
+                                <Image Source="{Binding ImageUrl}" Height="28" />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+
+                    <GridViewColumn Header="有効" Width="45">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <!-- OneWayだとクリック時にバインドが外れるためTwoWay。失敗時はコードビハインドで戻す -->
                                 <CheckBox
-                                    IsChecked="{Binding IsEnabled, Mode=OneWay}"
+                                    IsChecked="{Binding IsEnabled, Mode=TwoWay}"
+                                    IsEnabled="{Binding IsManageable}"
+                                    ToolTip="{Binding ManageableToolTip}"
                                     Click="ToggleIsEnabled_Click"/>
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>
                     </GridViewColumn>
-                    <GridViewColumn Header="一時停止">
+
+                    <GridViewColumn Header="一時停止" Width="65">
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
+                                <!-- OneWayだとクリック時にバインドが外れるためTwoWay。失敗時はコードビハインドで戻す -->
                                 <CheckBox
-                                    IsChecked="{Binding IsPaused, Mode=OneWay}"
+                                    IsChecked="{Binding IsPaused, Mode=TwoWay}"
+                                    IsEnabled="{Binding IsManageable}"
+                                    ToolTip="{Binding ManageableToolTip}"
                                     Click="ToggleIsPaused_Click"/>
                             </DataTemplate>
                         </GridViewColumn.CellTemplate>

--- a/JTSA/Panels/ChannelPointPanel.xaml.cs
+++ b/JTSA/Panels/ChannelPointPanel.xaml.cs
@@ -1,3 +1,4 @@
+using JTSA.Dao;
 using JTSA.Forms;
 using JTSA.Utility;
 using System.Collections.ObjectModel;
@@ -18,6 +19,12 @@ namespace JTSA.Panels
 
         /// <summary> 画面に表示している報酬一覧 </summary>
         public ObservableCollection<ChannelPointRewardForm> ChannelPointRewardFormList { get; } = [];
+
+        /// <summary> プリセット一覧 </summary>
+        public ObservableCollection<ChannelPointPresetForm> ChannelPointPresetFormList { get; } = [];
+
+        /// <summary> 選択中プリセットの内訳 </summary>
+        public ObservableCollection<ChannelPointPresetItemForm> ChannelPointPresetItemFormList { get; } = [];
 
         /// <summary> 一覧の下に常時出す注意書き </summary>
         private const string INFO_TEXT = "※画像追加はTwitch公式UIのみ対応です。画像サイズ調整ツール: https://xipher.booth.pm/items/6573903";
@@ -43,6 +50,8 @@ namespace JTSA.Panels
         public async Task Initialize()
         {
             await ReloadChannnelPoint();
+
+            ReloadPreset();
         }
 
 
@@ -265,6 +274,254 @@ namespace JTSA.Panels
                 MessageBox.Show($"作成に失敗しました。\n\n{result.ErrorMessage}");
             }
         }
+
+
+        #region ==================== プリセット ====================
+
+        /// <summary>
+        /// プリセット一覧を読み込み直す
+        /// </summary>
+        /// <param name="selectPresetId">読み込み後に選択しておくプリセットID</param>
+        public void ReloadPreset(long? selectPresetId = null)
+        {
+            var itemCounts = DAO_ChannelPointPreset.SelectItemCounts();
+
+            ChannelPointPresetFormList.Clear();
+
+            foreach (var header in DAO_ChannelPointPreset.SelectAllHeader())
+            {
+                ChannelPointPresetFormList.Add(new ChannelPointPresetForm
+                {
+                    PresetId = header.PresetId,
+                    PresetName = header.PresetName,
+                    ItemCount = itemCounts.TryGetValue(header.PresetId, out var count) ? count : 0,
+                    LastUsedDate = header.LastUsedDateTime.ToString("yyyy/MM/dd HH:mm")
+                });
+            }
+
+            if (selectPresetId != null)
+            {
+                PresetComboBox.SelectedItem =
+                    ChannelPointPresetFormList.FirstOrDefault(x => x.PresetId == selectPresetId);
+            }
+
+            // カテゴリ画面にも増減を反映する。
+            // 選択肢だけ差し替えるとバインド中のComboBoxが選択を失って紐づけを壊すため、
+            // カテゴリ一覧ごと作り直す（ReloadCategory は一覧をクリアしてから選択肢を入れ替える）
+            mainWindow.CategoryPanel.ReloadCategory();
+        }
+
+
+        /// <summary>
+        /// プリセット選択時：内訳を表示する
+        /// </summary>
+        private void PresetComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            ChannelPointPresetItemFormList.Clear();
+
+            if (PresetComboBox.SelectedItem is not ChannelPointPresetForm preset)
+            {
+                PresetItemListView.Visibility = Visibility.Collapsed;
+                PresetDetailStatus.Text = "プリセットを選択すると内容が表示されます。";
+                return;
+            }
+
+            // 名前変更しやすいよう、選択したプリセット名を入力欄へ入れておく
+            PresetNameTextBox.Text = preset.PresetName;
+
+            var items = DAO_ChannelPointPreset.SelectItemsByPresetId(preset.PresetId);
+
+            foreach (var item in items.OrderByDescending(x => x.IsEnabled).ThenBy(x => x.RewardTitle))
+            {
+                var reward = ChannelPointRewardFormList.FirstOrDefault(x => x.RewardId == item.RewardId);
+
+                ChannelPointPresetItemFormList.Add(new ChannelPointPresetItemForm
+                {
+                    RewardId = item.RewardId,
+                    RewardTitle = item.RewardTitle,
+                    IsEnabled = item.IsEnabled,
+                    IsExisting = reward != null && reward.IsManageable
+                });
+            }
+
+            var missingCount = ChannelPointPresetItemFormList.Count(x => !x.IsExisting);
+
+            PresetItemListView.Visibility = Visibility.Visible;
+            PresetDetailStatus.Text =
+                $"「{preset.PresetName}」：ON {ChannelPointPresetItemFormList.Count(x => x.IsEnabled)}件 / "
+                + $"OFF {ChannelPointPresetItemFormList.Count(x => !x.IsEnabled)}件"
+                + (missingCount > 0 ? $"　※{missingCount}件は報酬が見つからないため適用時にスキップされます" : "")
+                + $"　最終適用: {preset.LastUsedDate}";
+        }
+
+
+        /// <summary>
+        /// 適用ボタン押下
+        /// </summary>
+        private async void ApplyPresetButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (PresetComboBox.SelectedItem is not ChannelPointPresetForm preset)
+            {
+                MessageBox.Show("適用するプリセットを選択してください。");
+                return;
+            }
+
+            ApplyPresetButton.IsEnabled = false;
+
+            // 画面の一覧をそのまま渡すことで、更新結果が即座に画面へ反映される
+            var result = await ChannelPointService.ApplyPresetAsync(
+                preset.PresetId,
+                ChannelPointRewardFormList.ToList());
+
+            ApplyPresetButton.IsEnabled = true;
+
+            // 適用日時と件数を反映する
+            ReloadPreset(preset.PresetId);
+
+            if (result.IsSuccess)
+            {
+                ChannelPointGetStatus.Text = result.SummaryText;
+            }
+            else
+            {
+                MessageBox.Show($"{result.SummaryText}\n\n{result.ErrorMessage}");
+            }
+        }
+
+
+        /// <summary>
+        /// 新規保存ボタン押下：今の一覧の有効/無効を新しいプリセットとして保存する
+        /// </summary>
+        private void SavePresetButton_Click(object sender, RoutedEventArgs e)
+        {
+            var presetName = PresetNameTextBox.Text.Trim();
+
+            if (string.IsNullOrEmpty(presetName))
+            {
+                MessageBox.Show("プリセット名を入力してください。");
+                return;
+            }
+
+            var savedPresetId = SavePreset(presetName, null);
+            if (savedPresetId == null) return;
+
+            ReloadPreset(savedPresetId);
+
+            MessageBox.Show($"プリセット「{presetName}」を保存しました。");
+        }
+
+
+        /// <summary>
+        /// 上書き保存ボタン押下：選択中のプリセットを今の一覧の状態で置き換える
+        /// </summary>
+        private void OverwritePresetButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (PresetComboBox.SelectedItem is not ChannelPointPresetForm preset)
+            {
+                MessageBox.Show("上書きするプリセットを選択してください。");
+                return;
+            }
+
+            var confirm = MessageBox.Show(
+                $"プリセット「{preset.PresetName}」を、今の一覧の有効/無効で上書きします。よろしいですか？",
+                "プリセットの上書き保存", MessageBoxButton.OKCancel);
+
+            if (confirm != MessageBoxResult.OK) return;
+
+            var savedPresetId = SavePreset(preset.PresetName, preset.PresetId);
+            if (savedPresetId == null) return;
+
+            ReloadPreset(savedPresetId);
+
+            MessageBox.Show($"プリセット「{preset.PresetName}」を上書きしました。");
+        }
+
+
+        /// <summary>
+        /// 現在の一覧をプリセットとして保存する共通処理
+        /// </summary>
+        /// <param name="presetName">プリセット名</param>
+        /// <param name="presetId">上書き対象。nullなら新規</param>
+        /// <returns>保存したプリセットID。保存できなかった場合はnull</returns>
+        private long? SavePreset(string presetName, long? presetId)
+        {
+            var savedPresetId = ChannelPointService.SavePreset(
+                presetName,
+                ChannelPointRewardFormList.ToList(),
+                presetId);
+
+            if (savedPresetId == null)
+            {
+                MessageBox.Show("保存できる報酬がありません。\n\nプリセットに保存できるのは「操作可能（✔）」の報酬だけです。");
+
+                mainWindow.AppLogPanel.Error(GetType().Name, $"プリセット保存失敗 「 {presetName} 」：対象の報酬が0件");
+                return null;
+            }
+
+            mainWindow.AppLogPanel.Success(GetType().Name, $"プリセット保存 「 {presetName} 」");
+
+            return savedPresetId;
+        }
+
+
+        /// <summary>
+        /// 名前変更ボタン押下
+        /// </summary>
+        private void RenamePresetButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (PresetComboBox.SelectedItem is not ChannelPointPresetForm preset)
+            {
+                MessageBox.Show("名前を変更するプリセットを選択してください。");
+                return;
+            }
+
+            var presetName = PresetNameTextBox.Text.Trim();
+            if (string.IsNullOrEmpty(presetName))
+            {
+                MessageBox.Show("新しいプリセット名を入力してください。");
+                return;
+            }
+
+            var isSuccess = DAO_ChannelPointPreset.UpdateName(preset.PresetId, presetName);
+
+            mainWindow.AppLogPanel.AddSwitchLog(isSuccess, GetType().Name,
+                $"プリセット名変更 「 {preset.PresetName} 」→「 {presetName} 」",
+                $"プリセット名変更失敗 「 {preset.PresetName} 」"
+            );
+
+            ReloadPreset(preset.PresetId);
+        }
+
+
+        /// <summary>
+        /// 削除ボタン押下
+        /// </summary>
+        private void DeletePresetButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (PresetComboBox.SelectedItem is not ChannelPointPresetForm preset)
+            {
+                MessageBox.Show("削除するプリセットを選択してください。");
+                return;
+            }
+
+            var confirm = MessageBox.Show(
+                $"プリセット「{preset.PresetName}」を削除します。よろしいですか？",
+                "プリセットの削除", MessageBoxButton.OKCancel);
+
+            if (confirm != MessageBoxResult.OK) return;
+
+            var isSuccess = DAO_ChannelPointPreset.Delete(preset.PresetId);
+
+            mainWindow.AppLogPanel.AddSwitchLog(isSuccess, GetType().Name,
+                $"プリセット削除 「 {preset.PresetName} 」",
+                $"プリセット削除失敗 「 {preset.PresetName} 」"
+            );
+
+            PresetNameTextBox.Text = "";
+            ReloadPreset();
+        }
+
+        #endregion
 
 
         #region ==================== コピー ====================

--- a/JTSA/Panels/ChannelPointPanel.xaml.cs
+++ b/JTSA/Panels/ChannelPointPanel.xaml.cs
@@ -134,23 +134,18 @@ namespace JTSA.Panels
             ReloadButton.IsEnabled = false;
             ChannelPointGetStatus.Text = "チャンネルポイント取得中...";
 
-            var rewards = await ChannelPointService.FetchRewardsAsync();
+            var fetchResult = await ChannelPointService.FetchRewardsAsync();
 
             ChannelPointRewardFormList.Clear();
 
-            if (rewards != null)
+            if (fetchResult != null)
             {
-                foreach (var reward in rewards)
+                foreach (var reward in fetchResult.Rewards)
                 {
                     ChannelPointRewardFormList.Add(reward);
                 }
 
-                var lockedCount = rewards.Count(x => !x.IsManageable);
-                var lockedText = lockedCount > 0
-                    ? $" / 🔒 操作不可 {lockedCount}件（Twitchの Web 画面から作成された報酬です）"
-                    : "";
-
-                ChannelPointGetStatus.Text = $"取得成功！ ({rewards.Count}件){lockedText}\n{INFO_TEXT}";
+                ChannelPointGetStatus.Text = BuildStatusText(fetchResult);
                 mainWindow.AppLogPanel.Success(GetType().Name, appLogProcessName);
             }
             else
@@ -162,6 +157,45 @@ namespace JTSA.Panels
             ReloadButton.IsEnabled = true;
 
             mainWindow.AppLogPanel.ProcessEnd(GetType().Name, appLogProcessName);
+        }
+
+
+        /// <summary>
+        /// 一覧上部に出すステータス文言を組み立てる。
+        ///
+        /// 「本当に操作可能な報酬が0件」なのか「操作可否を判定できなかった」のかは
+        /// 対処法が全く違うため、必ず区別して表示する。
+        /// </summary>
+        /// <param name="fetchResult">取得結果</param>
+        /// <returns>表示するステータス文言</returns>
+        private static string BuildStatusText(ChannelPointFetchResult fetchResult)
+        {
+            var totalCount = fetchResult.Rewards.Count;
+            var manageableCount = fetchResult.Rewards.Count(x => x.IsManageable);
+            var lockedCount = totalCount - manageableCount;
+
+            if (!fetchResult.IsManageableCheckSucceeded)
+            {
+                return $"取得成功！ ({totalCount}件)\n"
+                     + "⚠ 操作可否の判定に失敗したため、全件を操作不可として表示しています。"
+                     + "「更新」で再試行してください（解消しない場合は Setting タブから再認証）。\n"
+                     + INFO_TEXT;
+            }
+
+            var statusText = $"取得成功！ ({totalCount}件) / ✔ 操作可能 {manageableCount}件 / 🔒 操作不可 {lockedCount}件";
+
+            if (manageableCount == 0 && totalCount > 0)
+            {
+                statusText += "\n⚠ このアプリから操作できる報酬がありません。"
+                            + "🔒 の報酬にチェックを入れて「選択をコピー」すると、操作できる報酬が作られます。"
+                            + "（プリセットの保存も操作可能な報酬が必要です）";
+            }
+            else if (lockedCount > 0)
+            {
+                statusText += "\n🔒 は Twitch の Web 画面から作成された報酬です。コピーするとこのアプリから操作できるようになります。";
+            }
+
+            return statusText + "\n" + INFO_TEXT;
         }
 
 

--- a/JTSA/Panels/ChannelPointPanel.xaml.cs
+++ b/JTSA/Panels/ChannelPointPanel.xaml.cs
@@ -1,23 +1,11 @@
-﻿using JTSA.Models;
-using System;
-using System.Collections.Generic;
+using JTSA.Forms;
+using JTSA.Utility;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using TwitchLib.Api.Helix.Models.ChannelPoints; // CustomReward用
-using TwitchLib.Api.Helix.Models.ChannelPoints.UpdateCustomReward;
 using TwitchLib.Api.Helix.Models.ChannelPoints.CreateCustomReward;
-using JTSA.Utility;
 
 namespace JTSA.Panels
 {
@@ -27,37 +15,62 @@ namespace JTSA.Panels
     public partial class ChannelPointPanel : UserControl
     {
         MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
+
+        /// <summary> 画面に表示している報酬一覧 </summary>
+        public ObservableCollection<ChannelPointRewardForm> ChannelPointRewardFormList { get; } = [];
+
+        /// <summary> 一覧の下に常時出す注意書き </summary>
+        private const string INFO_TEXT = "※画像追加はTwitch公式UIのみ対応です。画像サイズ調整ツール: https://xipher.booth.pm/items/6573903";
+
+        /// <summary> 最後にソートした列と方向 </summary>
+        private GridViewColumnHeader? _lastHeaderClicked = null;
+        private ListSortDirection _lastDirection = ListSortDirection.Ascending;
+
+
         public ChannelPointPanel()
         {
             InitializeComponent();
+
+            // 画面紐づけ
+            DataContext = this;
         }
 
-        // ★追加：最後にソートした列と方向を記憶するための変数
-        private GridViewColumnHeader _lastHeaderClicked = null;
-        private ListSortDirection _lastDirection = ListSortDirection.Ascending;
 
-        // キャッシュされた報酬のリスト
-        private List<CustomReward> _cachedRewards = null;
+        /// <summary>
+        /// 遅延初期化。認証が終わっていないとAPIを叩けないため、
+        /// コンストラクタではなくMainWindowの起動シーケンスから呼ばれる。
+        /// </summary>
+        public async Task Initialize()
+        {
+            await ReloadChannnelPoint();
+        }
 
-        // ★追加：ヘッダークリック時のイベントハンドラ
+
+        /// <summary>
+        /// ヘッダークリック時（列ソート）
+        /// </summary>
         private void GridViewColumnHeader_Click(object sender, RoutedEventArgs e)
         {
             if (e.OriginalSource is GridViewColumnHeader headerClicked)
             {
                 // ヘッダーに対応するプロパティ名を取得
                 string sortBy = "";
-                if (headerClicked.Column.DisplayMemberBinding is Binding binding)
+                if (headerClicked.Column?.DisplayMemberBinding is Binding binding)
                 {
                     sortBy = binding.Path.Path;
                 }
                 // 画像など、DisplayMemberBinding以外を使っている列の場合の対応
-                else if (headerClicked.Column.Header.ToString() == "有効")
+                else if (headerClicked.Column?.Header?.ToString() == "有効")
                 {
-                    sortBy = "IsEnabled";
+                    sortBy = nameof(ChannelPointRewardForm.IsEnabled);
                 }
-                else if (headerClicked.Column.Header.ToString() == "一時停止")
+                else if (headerClicked.Column?.Header?.ToString() == "一時停止")
                 {
-                    sortBy = "IsPaused";
+                    sortBy = nameof(ChannelPointRewardForm.IsPaused);
+                }
+                else if (headerClicked.Column?.Header?.ToString() == "操作可能")
+                {
+                    sortBy = nameof(ChannelPointRewardForm.IsManageable);
                 }
 
                 if (string.IsNullOrEmpty(sortBy)) return;
@@ -66,8 +79,10 @@ namespace JTSA.Panels
                 ListSortDirection direction;
                 if (headerClicked != _lastHeaderClicked)
                 {
-                    // IsEnabled, IsPaused の場合は初回降順、それ以外は昇順
-                    if (sortBy == "IsEnabled" || sortBy == "IsPaused")
+                    // 真偽値の列は初回降順、それ以外は昇順
+                    if (sortBy == nameof(ChannelPointRewardForm.IsEnabled)
+                     || sortBy == nameof(ChannelPointRewardForm.IsPaused)
+                     || sortBy == nameof(ChannelPointRewardForm.IsManageable))
                         direction = ListSortDirection.Descending;
                     else
                         direction = ListSortDirection.Ascending;
@@ -89,111 +104,139 @@ namespace JTSA.Panels
                 _lastDirection = direction;
             }
         }
-        public async void ReloadChannnelPoint(bool forceReload = false)
+
+
+        /// <summary>
+        /// 更新ボタン押下
+        /// </summary>
+        private async void ReloadButton_Click(object sender, RoutedEventArgs e)
+        {
+            await ReloadChannnelPoint();
+        }
+
+
+        /// <summary>
+        /// チャンネルポイント一覧をAPIから取り直して画面へ反映する
+        /// </summary>
+        public async Task ReloadChannnelPoint()
         {
             var appLogProcessName = mainWindow.AppLogPanel.ProcessStart(GetType().Name, "チャンネルポイントリスト再読み込み");
+
+            ReloadButton.IsEnabled = false;
             ChannelPointGetStatus.Text = "チャンネルポイント取得中...";
-            ChannelPointListView.ItemsSource = null;
 
-            // キャッシュがなければ取得、forceReload指定時は再取得
-            if (_cachedRewards == null || forceReload)
-            {
-                _cachedRewards = await TwitchHelper.GetCustomRewardsAsync();
-            }
-            var rewards = _cachedRewards;
+            var rewards = await ChannelPointService.FetchRewardsAsync();
 
-            string info = "※画像追加はTwitch公式UIのみ対応です。画像サイズ調整ツール: https://xipher.booth.pm/items/6573903";
+            ChannelPointRewardFormList.Clear();
 
             if (rewards != null)
             {
-                rewards.Sort((a, b) => a.Cost.CompareTo(b.Cost));
-                ChannelPointListView.ItemsSource = rewards;
-                ChannelPointGetStatus.Text = $"取得成功！ ({rewards.Count}件)\n{info}";
+                foreach (var reward in rewards)
+                {
+                    ChannelPointRewardFormList.Add(reward);
+                }
+
+                var lockedCount = rewards.Count(x => !x.IsManageable);
+                var lockedText = lockedCount > 0
+                    ? $" / 🔒 操作不可 {lockedCount}件（Twitchの Web 画面から作成された報酬です）"
+                    : "";
+
+                ChannelPointGetStatus.Text = $"取得成功！ ({rewards.Count}件){lockedText}\n{INFO_TEXT}";
                 mainWindow.AppLogPanel.Success(GetType().Name, appLogProcessName);
             }
             else
             {
-                ChannelPointGetStatus.Text = $"チャンネルポイントの取得に失敗しました。\n{info}";
+                ChannelPointGetStatus.Text = $"チャンネルポイントの取得に失敗しました。\n{INFO_TEXT}";
                 mainWindow.AppLogPanel.Error(GetType().Name, "チャンネルポイントリスト取得失敗");
             }
+
+            ReloadButton.IsEnabled = true;
 
             mainWindow.AppLogPanel.ProcessEnd(GetType().Name, appLogProcessName);
         }
 
-        // 有効/無効トグル
+
+        /// <summary>
+        /// 有効/無効トグル
+        /// </summary>
         private async void ToggleIsEnabled_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is CheckBox checkBox && checkBox.DataContext is CustomReward reward)
-            {
-                // キャッシュから該当する CustomReward を取得
-                var cached = _cachedRewards?.FirstOrDefault(r => r.Id == reward.Id);
-                if (cached == null)
-                {
-                    MessageBox.Show("キャッシュから該当のリワードが見つかりませんでした");
-                    return;
-                }
+            // クリックされたチェックボックス自身の行を対象にする（選択行ではない）
+            if (sender is not CheckBox checkBox || checkBox.DataContext is not ChannelPointRewardForm reward) return;
 
-                var request = new UpdateCustomRewardRequest
-                {
-                    // キャッシュの値を元に反転
-                    IsEnabled = !cached.IsEnabled
-                };
-                var updated = await TwitchHelper.UpdateCustomRewardAsync(cached.Id, request);
-                if (updated != null)
-                {
-                    // キャッシュをクリアして再取得
-                    _cachedRewards = null;
-                    ReloadChannnelPoint();
-                }
-                else
-                {
-                    MessageBox.Show("有効/無効の切り替えに失敗しました");
-                }
+            // TwoWayバインドによりクリック時点でFormへ反映済み。その値をそのままAPIへ送る
+            var requestValue = reward.IsEnabled;
+
+            var isSuccess = await ChannelPointService.SetEnabledAsync(reward, requestValue);
+
+            mainWindow.AppLogPanel.AddSwitchLog(isSuccess, GetType().Name,
+                $"有効/無効の切り替え成功 「 {reward.Title} 」→ {(requestValue ? "有効" : "無効")}",
+                $"有効/無効の切り替え失敗 「 {reward.Title} 」"
+            );
+
+            if (!isSuccess)
+            {
+                // 送信に失敗したので画面の見た目を元に戻す
+                reward.IsEnabled = !requestValue;
+                MessageBox.Show("有効/無効の切り替えに失敗しました");
             }
         }
 
-        // 一時停止トグル
+
+        /// <summary>
+        /// 一時停止トグル
+        /// </summary>
         private async void ToggleIsPaused_Click(object sender, RoutedEventArgs e)
         {
-            if (ChannelPointListView.SelectedItem is CustomReward reward)
+            // クリックされたチェックボックス自身の行を対象にする（選択行ではない）
+            if (sender is not CheckBox checkBox || checkBox.DataContext is not ChannelPointRewardForm reward) return;
+
+            // TwoWayバインドによりクリック時点でFormへ反映済み。その値をそのままAPIへ送る
+            var requestValue = reward.IsPaused;
+
+            var isSuccess = await ChannelPointService.SetPausedAsync(reward, requestValue);
+
+            mainWindow.AppLogPanel.AddSwitchLog(isSuccess, GetType().Name,
+                $"一時停止の切り替え成功 「 {reward.Title} 」→ {(requestValue ? "一時停止" : "再開")}",
+                $"一時停止の切り替え失敗 「 {reward.Title} 」"
+            );
+
+            if (!isSuccess)
             {
-                var request = new UpdateCustomRewardRequest
-                {
-                    IsPaused = !reward.IsPaused
-                };
-                var updated = await TwitchHelper.UpdateCustomRewardAsync(reward.Id, request);
-                if (updated != null)
-                {
-                    ReloadChannnelPoint();
-                }
-                else
-                {
-                    MessageBox.Show("一時停止の切り替えに失敗しました");
-                }
+                // 送信に失敗したので画面の見た目を元に戻す
+                reward.IsPaused = !requestValue;
+                MessageBox.Show("一時停止の切り替えに失敗しました");
             }
         }
 
-        // 新規作成ボタン押下
+
+        /// <summary>
+        /// 新規作成ボタン押下
+        /// </summary>
         private void CreateRewardButton_Click(object sender, RoutedEventArgs e)
         {
             RewardFormPanel.Visibility = Visibility.Visible;
             RewardNameTextBox.Text = "";
             RewardCostTextBox.Text = "";
-            RewardImageUrlTextBox.Text = "";
         }
 
-        // キャンセルボタン押下
+
+        /// <summary>
+        /// キャンセルボタン押下
+        /// </summary>
         private void CreateRewardCancelButton_Click(object sender, RoutedEventArgs e)
         {
             RewardFormPanel.Visibility = Visibility.Collapsed;
         }
 
-        // 作成ボタン押下
+
+        /// <summary>
+        /// 作成ボタン押下
+        /// </summary>
         private async void CreateRewardSubmitButton_Click(object sender, RoutedEventArgs e)
         {
             string name = RewardNameTextBox.Text.Trim();
             string costText = RewardCostTextBox.Text.Trim();
-            string imageUrl = RewardImageUrlTextBox.Text.Trim();
 
             if (string.IsNullOrEmpty(name) || !int.TryParse(costText, out int cost) || cost < 1)
             {
@@ -205,8 +248,7 @@ namespace JTSA.Panels
             {
                 Title = name,
                 Cost = cost,
-                // 画像URLはTwitch APIの仕様上、作成時には直接指定できません（TwitchのUIでのみ設定可能）。
-                // ここでは説明用にプロンプトや他の項目を追加できます。
+                // 画像URLはTwitch APIの仕様上、作成時には直接指定できない（TwitchのWeb画面でのみ設定可能）
                 Prompt = "",
                 IsEnabled = true
             };
@@ -216,8 +258,7 @@ namespace JTSA.Panels
             {
                 MessageBox.Show("作成しました。");
                 RewardFormPanel.Visibility = Visibility.Collapsed;
-                _cachedRewards = null;
-                ReloadChannnelPoint(true);
+                await ReloadChannnelPoint();
             }
             else
             {

--- a/JTSA/Panels/ChannelPointPanel.xaml.cs
+++ b/JTSA/Panels/ChannelPointPanel.xaml.cs
@@ -167,18 +167,18 @@ namespace JTSA.Panels
             // TwoWayバインドによりクリック時点でFormへ反映済み。その値をそのままAPIへ送る
             var requestValue = reward.IsEnabled;
 
-            var isSuccess = await ChannelPointService.SetEnabledAsync(reward, requestValue);
+            var result = await ChannelPointService.SetEnabledAsync(reward, requestValue);
 
-            mainWindow.AppLogPanel.AddSwitchLog(isSuccess, GetType().Name,
+            mainWindow.AppLogPanel.AddSwitchLog(result.IsSuccess, GetType().Name,
                 $"有効/無効の切り替え成功 「 {reward.Title} 」→ {(requestValue ? "有効" : "無効")}",
-                $"有効/無効の切り替え失敗 「 {reward.Title} 」"
+                $"有効/無効の切り替え失敗 「 {reward.Title} 」：{result.ErrorMessage}"
             );
 
-            if (!isSuccess)
+            if (!result.IsSuccess)
             {
                 // 送信に失敗したので画面の見た目を元に戻す
                 reward.IsEnabled = !requestValue;
-                MessageBox.Show("有効/無効の切り替えに失敗しました");
+                MessageBox.Show($"有効/無効の切り替えに失敗しました。\n\n{result.ErrorMessage}");
             }
         }
 
@@ -194,18 +194,18 @@ namespace JTSA.Panels
             // TwoWayバインドによりクリック時点でFormへ反映済み。その値をそのままAPIへ送る
             var requestValue = reward.IsPaused;
 
-            var isSuccess = await ChannelPointService.SetPausedAsync(reward, requestValue);
+            var result = await ChannelPointService.SetPausedAsync(reward, requestValue);
 
-            mainWindow.AppLogPanel.AddSwitchLog(isSuccess, GetType().Name,
+            mainWindow.AppLogPanel.AddSwitchLog(result.IsSuccess, GetType().Name,
                 $"一時停止の切り替え成功 「 {reward.Title} 」→ {(requestValue ? "一時停止" : "再開")}",
-                $"一時停止の切り替え失敗 「 {reward.Title} 」"
+                $"一時停止の切り替え失敗 「 {reward.Title} 」：{result.ErrorMessage}"
             );
 
-            if (!isSuccess)
+            if (!result.IsSuccess)
             {
                 // 送信に失敗したので画面の見た目を元に戻す
                 reward.IsPaused = !requestValue;
-                MessageBox.Show("一時停止の切り替えに失敗しました");
+                MessageBox.Show($"一時停止の切り替えに失敗しました。\n\n{result.ErrorMessage}");
             }
         }
 
@@ -254,16 +254,151 @@ namespace JTSA.Panels
             };
 
             var result = await TwitchHelper.CreateCustomRewardAsync(req);
-            if (result != null && result.Count > 0)
+            if (result.IsSuccess)
             {
-                MessageBox.Show("作成しました。");
+                MessageBox.Show("作成しました。\n\n画像は Twitch の Web 画面から設定してください。");
                 RewardFormPanel.Visibility = Visibility.Collapsed;
                 await ReloadChannnelPoint();
             }
             else
             {
-                MessageBox.Show("作成に失敗しました。");
+                MessageBox.Show($"作成に失敗しました。\n\n{result.ErrorMessage}");
             }
         }
+
+
+        #region ==================== コピー ====================
+
+        /// <summary>
+        /// 行内のコピーボタン押下（1件だけコピー）
+        /// </summary>
+        private async void CopyRewardButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button button || button.Tag is not ChannelPointRewardForm reward) return;
+
+            await CopyRewardsAsync([reward]);
+        }
+
+
+        /// <summary>
+        /// ツールバーの「選択をコピー」押下（チェックした分をまとめてコピー）
+        /// </summary>
+        private async void CopySelectedButton_Click(object sender, RoutedEventArgs e)
+        {
+            var targets = ChannelPointRewardFormList.Where(x => x.IsSelected && x.CanCopy).ToList();
+
+            if (targets.Count == 0)
+            {
+                MessageBox.Show("コピーする報酬にチェックを入れてください。\n\nコピーできるのは「操作可能」列が 🔒 の報酬だけです。");
+                return;
+            }
+
+            await CopyRewardsAsync(targets);
+        }
+
+
+        /// <summary>
+        /// 報酬のコピーを実行し、結果をまとめて通知する
+        /// </summary>
+        /// <param name="targets">コピー対象</param>
+        private async Task CopyRewardsAsync(List<ChannelPointRewardForm> targets)
+        {
+            var appLogProcessName = mainWindow.AppLogPanel.ProcessStart(GetType().Name, "チャンネルポイント報酬コピー");
+
+            CopySelectedButton.IsEnabled = false;
+
+            var suffix = ChannelPointService.GetCopySuffix();
+            var results = new List<ChannelPointCopyResult>();
+
+            foreach (var target in targets)
+            {
+                var result = await ChannelPointService.CopyRewardAsync(target, suffix);
+                results.Add(result);
+
+                mainWindow.AppLogPanel.AddSwitchLog(result.IsSuccess, GetType().Name,
+                    $"報酬コピー成功 「 {result.SourceTitle} 」→「 {result.CreatedTitle} 」",
+                    $"報酬コピー失敗 「 {result.SourceTitle} 」：{result.ErrorMessage}"
+                );
+            }
+
+            CopySelectedButton.IsEnabled = true;
+
+            // コピー分を一覧へ反映する
+            await ReloadChannnelPoint();
+
+            ShowCopyResult(results);
+
+            mainWindow.AppLogPanel.ProcessEnd(GetType().Name, appLogProcessName);
+        }
+
+
+        /// <summary>
+        /// コピー結果と、ユーザーが Web 画面で行う必要がある後始末を案内する
+        /// </summary>
+        /// <param name="results">コピー結果</param>
+        private void ShowCopyResult(List<ChannelPointCopyResult> results)
+        {
+            var successList = results.Where(x => x.IsSuccess).ToList();
+            var failureList = results.Where(x => !x.IsSuccess).ToList();
+
+            var message = new System.Text.StringBuilder();
+
+            if (successList.Count > 0)
+            {
+                message.AppendLine($"■ コピーしました（{successList.Count}件）");
+                foreach (var success in successList)
+                {
+                    message.AppendLine($"　「{success.SourceTitle}」→「{success.CreatedTitle}」");
+                }
+                message.AppendLine();
+                message.AppendLine("・画像は Twitch API では設定できないため引き継がれません。Twitch の Web 画面から設定してください。");
+                message.AppendLine("・コピー元の報酬はこのアプリからは削除できません。Twitch の Web 画面で無効化または削除してください。");
+            }
+
+            if (failureList.Count > 0)
+            {
+                if (successList.Count > 0) message.AppendLine();
+
+                message.AppendLine($"■ 失敗しました（{failureList.Count}件）");
+                foreach (var failure in failureList)
+                {
+                    message.AppendLine($"　「{failure.SourceTitle}」：{failure.ErrorMessage}");
+                }
+            }
+
+            MessageBox.Show(message.ToString(), "チャンネルポイントのコピー結果");
+        }
+
+
+        /// <summary>
+        /// Twitch のチャンネルポイント設定ページを開く
+        /// （コピー元の削除や画像設定は Web 画面でしか行えないため）
+        /// </summary>
+        private void OpenTwitchRewardPageButton_Click(object sender, RoutedEventArgs e)
+        {
+            var url = $"https://dashboard.twitch.tv/u/{JTSAHelper.LoginName}/viewer-rewards/channel-points/rewards";
+
+            var isSuccess = true;
+            try
+            {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = url,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                isSuccess = false;
+                mainWindow.AppLogPanel.Error(GetType().Name, "Twitch報酬設定ページを開けませんでした：" + ex.Message);
+            }
+
+            mainWindow.AppLogPanel.AddSwitchLog(isSuccess, GetType().Name,
+                "Twitch報酬設定ページを開きました",
+                "Twitch報酬設定ページを開けませんでした"
+            );
+        }
+
+        #endregion
     }
 }

--- a/JTSA/Panels/PlayingGamePanel.xaml.cs
+++ b/JTSA/Panels/PlayingGamePanel.xaml.cs
@@ -3,6 +3,7 @@ using JTSA.Forms;
 using JTSA.Models;
 using JTSA.Utility;
 using System.Collections.ObjectModel;
+using System.Security.Policy;
 using System.Text.Json;
 using System.Windows;
 using System.Windows.Controls;
@@ -382,7 +383,10 @@ namespace JTSA.Panels
         /// <returns></returns>
         public async Task AddSteamImageAsync(string categoryId, string urlText)
         {
-            string url = urlText.Trim();
+            string url = "";
+            if (!string.IsNullOrEmpty(urlText)) { 
+                url = urlText.Trim();
+            }
 
             var categoryData = await TwitchHelper.GetCategoryByGameId(categoryId);
 

--- a/JTSA/Panels/PlayingGamePanel.xaml.cs
+++ b/JTSA/Panels/PlayingGamePanel.xaml.cs
@@ -170,6 +170,9 @@ namespace JTSA.Panels
                     mainWindow.CurrentCategoryId = categoryData.Id;
                     mainWindow.CurrentCategoryName = categoryData.Name;
                     mainWindow.CurrentCategoryBoxArtUrl = categoryData.BoxArtUrl;
+
+                    // カテゴリに紐づくチャンネルポイントプリセットを適用する（紐づけが無ければ何もしない）
+                    await mainWindow.ApplyChannelPointPresetForCategoryAsync(categoryData.Id);
                 }
             }
         }

--- a/JTSA/Utility/ChannelPointService.cs
+++ b/JTSA/Utility/ChannelPointService.cs
@@ -1,0 +1,152 @@
+using JTSA.Forms;
+using System.Windows;
+using TwitchLib.Api.Helix.Models.ChannelPoints;
+using TwitchLib.Api.Helix.Models.ChannelPoints.UpdateCustomReward;
+
+namespace JTSA.Utility
+{
+    /// <summary>
+    /// チャンネルポイント報酬まわりのビジネスロジック。
+    /// TwitchHelper（API境界）と画面（ChannelPointPanel）の間に入り、
+    /// 「操作可否の判定」「コピー」「プリセット適用」といったアプリ固有の処理を担う。
+    /// </summary>
+    static class ChannelPointService
+    {
+        /// <summary>
+        /// チャンネルポイント報酬の一覧を取得する。
+        ///
+        /// Twitchの仕様上、Web画面や他アプリから作成された報酬はこのアプリからは更新／削除できない。
+        /// これを判別する公式なフラグは存在しないため、
+        /// 「全件（only_manageable_rewards=false）」と「自アプリ作成分のみ（=true）」の
+        /// 2回のGETを取り、後者に含まれるものだけ IsManageable = true とする。
+        /// </summary>
+        /// <returns>取得できた報酬一覧（コスト昇順）。失敗した場合はnull。</returns>
+        public static async Task<List<ChannelPointRewardForm>?> FetchRewardsAsync()
+        {
+            MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
+            var appLogProcessName = mainWindow.AppLogPanel.ProcessStart(nameof(ChannelPointService), "チャンネルポイント一覧取得");
+
+            var allRewards = await TwitchHelper.GetCustomRewardsAsync(onlyManageableRewards: false);
+            if (allRewards == null)
+            {
+                mainWindow.AppLogPanel.Error(nameof(ChannelPointService), "チャンネルポイント一覧取得失敗");
+                mainWindow.AppLogPanel.ProcessEnd(nameof(ChannelPointService), appLogProcessName);
+                return null;
+            }
+
+            // 自アプリ作成分のみの取得。ここが失敗した場合は「操作可否が不明」なので
+            // 一覧自体は返しつつ、全件を操作不可扱いにして誤操作を防ぐ。
+            var manageableRewards = await TwitchHelper.GetCustomRewardsAsync(onlyManageableRewards: true);
+            if (manageableRewards == null)
+            {
+                mainWindow.AppLogPanel.Error(nameof(ChannelPointService), "操作可能な報酬の判定に失敗したため全件を操作不可として表示します");
+            }
+
+            var manageableIds = manageableRewards?.Select(x => x.Id).ToHashSet() ?? [];
+
+            var results = allRewards
+                .Select(reward => ToForm(reward, manageableIds.Contains(reward.Id)))
+                .OrderBy(x => x.Cost)
+                .ToList();
+
+            mainWindow.AppLogPanel.Success(nameof(ChannelPointService),
+                $"チャンネルポイント一覧取得（全{results.Count}件／操作可能{results.Count(x => x.IsManageable)}件）");
+            mainWindow.AppLogPanel.ProcessEnd(nameof(ChannelPointService), appLogProcessName);
+
+            return results;
+        }
+
+
+        /// <summary>
+        /// 報酬の有効／無効を切り替える。成功した場合はFormの値も更新する。
+        /// </summary>
+        /// <param name="reward">対象の報酬</param>
+        /// <param name="isEnabled">設定する値</param>
+        /// <returns>true：成功</returns>
+        public static async Task<bool> SetEnabledAsync(ChannelPointRewardForm reward, bool isEnabled)
+        {
+            return await UpdateAsync(reward, new UpdateCustomRewardRequest { IsEnabled = isEnabled });
+        }
+
+
+        /// <summary>
+        /// 報酬の一時停止を切り替える。成功した場合はFormの値も更新する。
+        /// </summary>
+        /// <param name="reward">対象の報酬</param>
+        /// <param name="isPaused">設定する値</param>
+        /// <returns>true：成功</returns>
+        public static async Task<bool> SetPausedAsync(ChannelPointRewardForm reward, bool isPaused)
+        {
+            return await UpdateAsync(reward, new UpdateCustomRewardRequest { IsPaused = isPaused });
+        }
+
+
+        /// <summary>
+        /// 報酬を更新し、成功したらAPIが返した最新値をFormへ反映する。
+        /// 一覧の全件再取得を行わずに画面と実状態を一致させるための共通処理。
+        /// </summary>
+        /// <param name="reward">対象の報酬</param>
+        /// <param name="request">更新内容</param>
+        /// <returns>true：成功</returns>
+        private static async Task<bool> UpdateAsync(ChannelPointRewardForm reward, UpdateCustomRewardRequest request)
+        {
+            if (!reward.IsManageable) return false;
+
+            var updated = await TwitchHelper.UpdateCustomRewardAsync(reward.RewardId, request);
+            if (updated == null || updated.Count == 0) return false;
+
+            ApplyToForm(reward, updated[0]);
+
+            return true;
+        }
+
+
+        /// <summary>
+        /// TwitchLibのCustomRewardを画面用DTOへ詰め替える
+        /// </summary>
+        /// <param name="reward">APIレスポンス</param>
+        /// <param name="isManageable">このアプリから操作できるか</param>
+        /// <returns>画面用DTO</returns>
+        private static ChannelPointRewardForm ToForm(CustomReward reward, bool isManageable)
+        {
+            var form = new ChannelPointRewardForm
+            {
+                RewardId = reward.Id,
+                IsManageable = isManageable
+            };
+
+            ApplyToForm(form, reward);
+
+            return form;
+        }
+
+
+        /// <summary>
+        /// APIレスポンスの内容を既存のFormへ上書きする（IsManageableとIsSelectedは維持する）
+        /// </summary>
+        /// <param name="form">上書き先</param>
+        /// <param name="reward">APIレスポンス</param>
+        private static void ApplyToForm(ChannelPointRewardForm form, CustomReward reward)
+        {
+            form.Title = reward.Title ?? "";
+            form.Prompt = reward.Prompt ?? "";
+            form.Cost = reward.Cost;
+            form.ImageUrl = reward.Image?.Url1x ?? reward.DefaultImage?.Url1x ?? "";
+            form.BackgroundColor = reward.BackgroundColor ?? "";
+            form.IsUserInputRequired = reward.IsUserInputRequired;
+            form.ShouldRedemptionsSkipQueue = reward.ShouldRedemptionsSkipQueue;
+
+            // 上限・クールダウンは「有効フラグ＋値」の組で返るため、無効なら0として保持する
+            form.MaxPerStream = reward.MaxPerStreamSetting?.IsEnabled == true
+                ? reward.MaxPerStreamSetting.MaxPerStream : 0;
+            form.MaxPerUserPerStream = reward.MaxPerUserPerStreamSetting?.IsEnabled == true
+                ? reward.MaxPerUserPerStreamSetting.MaxPerUserPerStream : 0;
+            form.GlobalCooldownSeconds = reward.GlobalCooldownSetting?.IsEnabled == true
+                ? reward.GlobalCooldownSetting.GlobalCooldownSeconds : 0;
+
+            // INPC通知が必要なプロパティは最後に設定する
+            form.IsEnabled = reward.IsEnabled;
+            form.IsPaused = reward.IsPaused;
+        }
+    }
+}

--- a/JTSA/Utility/ChannelPointService.cs
+++ b/JTSA/Utility/ChannelPointService.cs
@@ -29,6 +29,23 @@ namespace JTSA.Utility
 
 
     /// <summary>
+    /// 報酬一覧の取得結果
+    /// </summary>
+    public class ChannelPointFetchResult
+    {
+        /// <summary> 取得した報酬一覧（コスト昇順） </summary>
+        public List<ChannelPointRewardForm> Rewards { get; set; } = [];
+
+        /// <summary>
+        /// 操作可否の判定に成功したか。
+        /// falseの場合、IsManageableは全件falseになっているだけで実際の可否は不明。
+        /// 「本当に全件が操作不可」なのか「判定できなかった」のかを画面で区別するために持つ。
+        /// </summary>
+        public bool IsManageableCheckSucceeded { get; set; }
+    }
+
+
+    /// <summary>
     /// プリセット適用の結果
     /// </summary>
     public class ChannelPointApplyResult
@@ -90,8 +107,8 @@ namespace JTSA.Utility
         /// 「全件（only_manageable_rewards=false）」と「自アプリ作成分のみ（=true）」の
         /// 2回のGETを取り、後者に含まれるものだけ IsManageable = true とする。
         /// </summary>
-        /// <returns>取得できた報酬一覧（コスト昇順）。失敗した場合はnull。</returns>
-        public static async Task<List<ChannelPointRewardForm>?> FetchRewardsAsync()
+        /// <returns>取得結果。一覧そのものの取得に失敗した場合はnull。</returns>
+        public static async Task<ChannelPointFetchResult?> FetchRewardsAsync()
         {
             MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
             var appLogProcessName = mainWindow.AppLogPanel.ProcessStart(nameof(ChannelPointService), "チャンネルポイント一覧取得");
@@ -114,19 +131,23 @@ namespace JTSA.Utility
 
             var manageableIds = manageableRewards?.Select(x => x.Id).ToHashSet() ?? [];
 
-            var results = allRewards
+            var rewards = allRewards
                 .Select(reward => ToForm(reward, manageableIds.Contains(reward.Id)))
                 .OrderBy(x => x.Cost)
                 .ToList();
 
             // プリセット編集画面がAPIを叩かずに報酬名を出せるようキャッシュしておく
-            SaveRewardCache(results);
+            SaveRewardCache(rewards);
 
             mainWindow.AppLogPanel.Success(nameof(ChannelPointService),
-                $"チャンネルポイント一覧取得（全{results.Count}件／操作可能{results.Count(x => x.IsManageable)}件）");
+                $"チャンネルポイント一覧取得（全{rewards.Count}件／操作可能{rewards.Count(x => x.IsManageable)}件）");
             mainWindow.AppLogPanel.ProcessEnd(nameof(ChannelPointService), appLogProcessName);
 
-            return results;
+            return new ChannelPointFetchResult
+            {
+                Rewards = rewards,
+                IsManageableCheckSucceeded = manageableRewards != null
+            };
         }
 
 
@@ -419,7 +440,7 @@ namespace JTSA.Utility
             var items = DAO_ChannelPointPreset.SelectItemsByPresetId(presetId);
 
             // 画面から渡されなかった場合はAPIから取り直す（カテゴリ紐づけの自動適用経路など）
-            var currentRewards = rewards ?? await FetchRewardsAsync();
+            var currentRewards = rewards ?? (await FetchRewardsAsync())?.Rewards;
             if (currentRewards == null)
             {
                 result.ErrorMessage = "チャンネルポイント一覧の取得に失敗したため適用できませんでした。";

--- a/JTSA/Utility/ChannelPointService.cs
+++ b/JTSA/Utility/ChannelPointService.cs
@@ -1,5 +1,6 @@
 using JTSA.Dao;
 using JTSA.Forms;
+using JTSA.Models;
 using System.Windows;
 using TwitchLib.Api.Helix.Models.ChannelPoints;
 using TwitchLib.Api.Helix.Models.ChannelPoints.CreateCustomReward;
@@ -24,6 +25,41 @@ namespace JTSA.Utility
 
         /// <summary> 失敗理由 </summary>
         public string ErrorMessage { get; set; } = "";
+    }
+
+
+    /// <summary>
+    /// プリセット適用の結果
+    /// </summary>
+    public class ChannelPointApplyResult
+    {
+        /// <summary> 適用処理を実行できたか（プリセット未存在や一覧取得失敗はfalse） </summary>
+        public bool IsSuccess { get; set; }
+
+        /// <summary> 適用したプリセット名 </summary>
+        public string PresetName { get; set; } = "";
+
+        /// <summary> 実際に変更した報酬の件数 </summary>
+        public int ChangedCount { get; set; }
+
+        /// <summary> 既に狙いの状態だったため変更不要だった件数 </summary>
+        public int UnchangedCount { get; set; }
+
+        /// <summary> 報酬が見つからない等でスキップした件数 </summary>
+        public int SkippedCount { get; set; }
+
+        /// <summary> 変更に失敗した件数 </summary>
+        public int FailedCount { get; set; }
+
+        /// <summary> 失敗理由（1件でも失敗した場合） </summary>
+        public string ErrorMessage { get; set; } = "";
+
+        /// <summary> ログ・画面に出す要約 </summary>
+        public string SummaryText =>
+            $"「{PresetName}」を適用（変更{ChangedCount}件／変更不要{UnchangedCount}件"
+            + (SkippedCount > 0 ? $"／スキップ{SkippedCount}件" : "")
+            + (FailedCount > 0 ? $"／失敗{FailedCount}件" : "")
+            + "）";
     }
 
 
@@ -83,11 +119,38 @@ namespace JTSA.Utility
                 .OrderBy(x => x.Cost)
                 .ToList();
 
+            // プリセット編集画面がAPIを叩かずに報酬名を出せるようキャッシュしておく
+            SaveRewardCache(results);
+
             mainWindow.AppLogPanel.Success(nameof(ChannelPointService),
                 $"チャンネルポイント一覧取得（全{results.Count}件／操作可能{results.Count(x => x.IsManageable)}件）");
             mainWindow.AppLogPanel.ProcessEnd(nameof(ChannelPointService), appLogProcessName);
 
             return results;
+        }
+
+
+        /// <summary>
+        /// 取得した報酬一覧を M_ChannelPoint へ同期する
+        /// </summary>
+        /// <param name="rewards">報酬一覧</param>
+        private static void SaveRewardCache(List<ChannelPointRewardForm> rewards)
+        {
+            var now = DateTime.Now;
+
+            var cacheData = rewards.Select(reward => new M_ChannelPoint
+            {
+                RewardId = reward.RewardId,
+                Title = reward.Title,
+                Cost = reward.Cost,
+                ImageUrl = reward.ImageUrl,
+                IsManageable = reward.IsManageable,
+                LastUsedDateTime = now,
+                CreatedDateTime = now,
+                UpdatedDateTime = now
+            }).ToList();
+
+            DAO_ChannelPoint.ReplaceAll(cacheData);
         }
 
         #endregion
@@ -270,6 +333,164 @@ namespace JTSA.Utility
             }
 
             return request;
+        }
+
+        #endregion
+
+
+        #region ==================== プリセット ====================
+
+        /// <summary>
+        /// 現在の「操作可能な全報酬」の有効／無効をプリセットとして保存する（全件スナップショット方式）。
+        ///
+        /// 操作不可な報酬を含めないのは、適用しても変更できず失敗するだけのため。
+        /// </summary>
+        /// <param name="presetName">プリセット名</param>
+        /// <param name="rewards">保存対象の報酬一覧（画面に表示中のもの）</param>
+        /// <param name="presetId">上書き対象のプリセットID。nullなら新規作成</param>
+        /// <returns>保存したプリセットID。対象が0件だった場合はnull</returns>
+        public static long? SavePreset(string presetName, List<ChannelPointRewardForm> rewards, long? presetId = null)
+        {
+            var targets = rewards.Where(x => x.IsManageable).ToList();
+            if (targets.Count == 0) return null;
+
+            var now = DateTime.Now;
+
+            // プレイリストと同じくUnixミリ秒で採番する
+            var savePresetId = presetId ?? JTSAHelper.GetCurrentUnixTimestampMillis();
+
+            var header = new T_ChannelPointPresetHeader
+            {
+                PresetId = savePresetId,
+                PresetName = presetName,
+                LastUsedDateTime = now,
+                CreatedDateTime = now,
+                UpdatedDateTime = now
+            };
+
+            var items = targets.Select(reward => new T_ChannelPointPresetItem
+            {
+                PresetId = savePresetId,
+                RewardId = reward.RewardId,
+                RewardTitle = reward.Title,
+                IsEnabled = reward.IsEnabled,
+                LastUsedDateTime = now,
+                CreatedDateTime = now,
+                UpdatedDateTime = now
+            }).ToList();
+
+            DAO_ChannelPointPreset.InsertUpdate(header, items);
+
+            return savePresetId;
+        }
+
+
+        /// <summary>
+        /// プリセットを適用する。
+        /// 現在の状態と突き合わせ、差分のある報酬だけ更新することで
+        /// 無駄なAPI呼び出しとレート制限を避ける。
+        /// </summary>
+        /// <param name="presetId">適用するプリセットID</param>
+        /// <param name="rewards">
+        /// 画面に表示中の報酬一覧。渡した場合はこのFormも更新されるので画面に即反映される。
+        /// nullの場合はAPIから取得し直す。
+        /// </param>
+        /// <returns>適用結果</returns>
+        public static async Task<ChannelPointApplyResult> ApplyPresetAsync(
+            long presetId,
+            List<ChannelPointRewardForm>? rewards = null)
+        {
+            MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
+            var appLogProcessName = mainWindow.AppLogPanel.ProcessStart(nameof(ChannelPointService), "チャンネルポイントプリセット適用");
+
+            var result = new ChannelPointApplyResult();
+
+            var header = DAO_ChannelPointPreset.SelectHeaderById(presetId);
+            if (header == null)
+            {
+                result.ErrorMessage = "プリセットが見つかりませんでした。";
+                mainWindow.AppLogPanel.Error(nameof(ChannelPointService), result.ErrorMessage);
+                mainWindow.AppLogPanel.ProcessEnd(nameof(ChannelPointService), appLogProcessName);
+                return result;
+            }
+
+            result.PresetName = header.PresetName;
+
+            var items = DAO_ChannelPointPreset.SelectItemsByPresetId(presetId);
+
+            // 画面から渡されなかった場合はAPIから取り直す（カテゴリ紐づけの自動適用経路など）
+            var currentRewards = rewards ?? await FetchRewardsAsync();
+            if (currentRewards == null)
+            {
+                result.ErrorMessage = "チャンネルポイント一覧の取得に失敗したため適用できませんでした。";
+                mainWindow.AppLogPanel.Error(nameof(ChannelPointService), result.ErrorMessage);
+                mainWindow.AppLogPanel.ProcessEnd(nameof(ChannelPointService), appLogProcessName);
+                return result;
+            }
+
+            foreach (var item in items)
+            {
+                var reward = currentRewards.FirstOrDefault(x => x.RewardId == item.RewardId);
+
+                // 報酬が削除された、または操作不可になった場合はスキップする
+                if (reward == null || !reward.IsManageable)
+                {
+                    result.SkippedCount++;
+                    continue;
+                }
+
+                // 既に狙いの状態なら何もしない（API呼び出しを減らす）
+                if (reward.IsEnabled == item.IsEnabled)
+                {
+                    result.UnchangedCount++;
+                    continue;
+                }
+
+                var updateResult = await SetEnabledAsync(reward, item.IsEnabled);
+
+                if (updateResult.IsSuccess)
+                {
+                    result.ChangedCount++;
+                }
+                else
+                {
+                    result.FailedCount++;
+                    result.ErrorMessage = updateResult.ErrorMessage;
+
+                    mainWindow.AppLogPanel.Error(nameof(ChannelPointService),
+                        $"プリセット適用失敗 「 {item.RewardTitle} 」：{updateResult.ErrorMessage}");
+                }
+            }
+
+            result.IsSuccess = result.FailedCount == 0;
+
+            DAO_ChannelPointPreset.UpdateLastUsed(presetId);
+
+            mainWindow.AppLogPanel.AddSwitchLog(result.IsSuccess, nameof(ChannelPointService),
+                result.SummaryText,
+                result.SummaryText + "：" + result.ErrorMessage
+            );
+            mainWindow.AppLogPanel.ProcessEnd(nameof(ChannelPointService), appLogProcessName);
+
+            return result;
+        }
+
+
+        /// <summary>
+        /// カテゴリに紐づいたプリセットを適用する。
+        /// 紐づけが無い場合は何もしない（ユーザーの明示的な指定がないカテゴリでは
+        /// チャンネルポイントの状態を勝手に変えない、という方針）。
+        /// </summary>
+        /// <param name="categoryId">カテゴリID</param>
+        /// <returns>適用した場合は結果。紐づけが無い場合はnull</returns>
+        public static async Task<ChannelPointApplyResult?> ApplyPresetForCategoryAsync(string categoryId)
+        {
+            if (string.IsNullOrEmpty(categoryId)) return null;
+
+            var category = DAO_Category.SelectOneById(categoryId);
+            if (category?.ChannelPointPresetId == null) return null;
+
+            return await ApplyPresetAsync(category.ChannelPointPresetId.Value);
         }
 
         #endregion

--- a/JTSA/Utility/ChannelPointService.cs
+++ b/JTSA/Utility/ChannelPointService.cs
@@ -1,10 +1,32 @@
+using JTSA.Dao;
 using JTSA.Forms;
 using System.Windows;
 using TwitchLib.Api.Helix.Models.ChannelPoints;
+using TwitchLib.Api.Helix.Models.ChannelPoints.CreateCustomReward;
 using TwitchLib.Api.Helix.Models.ChannelPoints.UpdateCustomReward;
+using static JTSA.Dao.DAO_Setting;
 
 namespace JTSA.Utility
 {
+    /// <summary>
+    /// 報酬コピーの結果（1件分）
+    /// </summary>
+    public class ChannelPointCopyResult
+    {
+        /// <summary> 成功したか </summary>
+        public bool IsSuccess { get; set; }
+
+        /// <summary> コピー元の報酬名 </summary>
+        public string SourceTitle { get; set; } = "";
+
+        /// <summary> 実際に作成された報酬名（接尾辞付き） </summary>
+        public string CreatedTitle { get; set; } = "";
+
+        /// <summary> 失敗理由 </summary>
+        public string ErrorMessage { get; set; } = "";
+    }
+
+
     /// <summary>
     /// チャンネルポイント報酬まわりのビジネスロジック。
     /// TwitchHelper（API境界）と画面（ChannelPointPanel）の間に入り、
@@ -12,6 +34,18 @@ namespace JTSA.Utility
     /// </summary>
     static class ChannelPointService
     {
+        /// <summary> Twitchの報酬名の最大文字数 </summary>
+        private const int TITLE_MAX_LENGTH = 45;
+
+        /// <summary> コピー時に付ける接尾辞の既定値 </summary>
+        public const string DEFAULT_COPY_SUFFIX = "'";
+
+        /// <summary> タイトル重複時に接尾辞を重ねて再試行する回数 </summary>
+        private const int COPY_RETRY_COUNT = 3;
+
+
+        #region ==================== 取得 ====================
+
         /// <summary>
         /// チャンネルポイント報酬の一覧を取得する。
         ///
@@ -56,14 +90,18 @@ namespace JTSA.Utility
             return results;
         }
 
+        #endregion
+
+
+        #region ==================== 更新 ====================
 
         /// <summary>
         /// 報酬の有効／無効を切り替える。成功した場合はFormの値も更新する。
         /// </summary>
         /// <param name="reward">対象の報酬</param>
         /// <param name="isEnabled">設定する値</param>
-        /// <returns>true：成功</returns>
-        public static async Task<bool> SetEnabledAsync(ChannelPointRewardForm reward, bool isEnabled)
+        /// <returns>成否と失敗理由</returns>
+        public static async Task<TwitchApiResult<bool>> SetEnabledAsync(ChannelPointRewardForm reward, bool isEnabled)
         {
             return await UpdateAsync(reward, new UpdateCustomRewardRequest { IsEnabled = isEnabled });
         }
@@ -74,8 +112,8 @@ namespace JTSA.Utility
         /// </summary>
         /// <param name="reward">対象の報酬</param>
         /// <param name="isPaused">設定する値</param>
-        /// <returns>true：成功</returns>
-        public static async Task<bool> SetPausedAsync(ChannelPointRewardForm reward, bool isPaused)
+        /// <returns>成否と失敗理由</returns>
+        public static async Task<TwitchApiResult<bool>> SetPausedAsync(ChannelPointRewardForm reward, bool isPaused)
         {
             return await UpdateAsync(reward, new UpdateCustomRewardRequest { IsPaused = isPaused });
         }
@@ -87,19 +125,157 @@ namespace JTSA.Utility
         /// </summary>
         /// <param name="reward">対象の報酬</param>
         /// <param name="request">更新内容</param>
-        /// <returns>true：成功</returns>
-        private static async Task<bool> UpdateAsync(ChannelPointRewardForm reward, UpdateCustomRewardRequest request)
+        /// <returns>成否と失敗理由</returns>
+        private static async Task<TwitchApiResult<bool>> UpdateAsync(ChannelPointRewardForm reward, UpdateCustomRewardRequest request)
         {
-            if (!reward.IsManageable) return false;
+            if (!reward.IsManageable)
+            {
+                return TwitchApiResult<bool>.Failure(TwitchApiErrorKind.NotManageable,
+                    "Twitch の Web 画面から作成された報酬のため操作できません。");
+            }
 
-            var updated = await TwitchHelper.UpdateCustomRewardAsync(reward.RewardId, request);
-            if (updated == null || updated.Count == 0) return false;
+            var result = await TwitchHelper.UpdateCustomRewardAsync(reward.RewardId, request);
 
-            ApplyToForm(reward, updated[0]);
+            if (!result.IsSuccess) return TwitchApiResult<bool>.Failure(result.ErrorKind, result.ErrorMessage);
 
-            return true;
+            if (result.Data == null || result.Data.Count == 0)
+            {
+                return TwitchApiResult<bool>.Failure(TwitchApiErrorKind.Unknown, "レスポンスが空でした");
+            }
+
+            ApplyToForm(reward, result.Data[0]);
+
+            return TwitchApiResult<bool>.Success(true);
         }
 
+        #endregion
+
+
+        #region ==================== コピー ====================
+
+        /// <summary>
+        /// コピー時にタイトルへ付ける接尾辞を取得する。
+        /// Twitchの報酬名はチャンネル内で一意でなければならないため、
+        /// 元と同名のコピーは作成できない。その回避策。
+        /// </summary>
+        /// <returns>設定値。未設定なら既定値</returns>
+        public static string GetCopySuffix()
+        {
+            var setting = DAO_Setting.SelectOneById(SettingName.ChannelPointCopySuffix);
+
+            return string.IsNullOrEmpty(setting?.Value) ? DEFAULT_COPY_SUFFIX : setting.Value;
+        }
+
+
+        /// <summary>
+        /// 操作不可な報酬を、このアプリの管理下（＝操作可能）へコピーする。
+        ///
+        /// 画像だけはTwitch APIで設定できないため引き継げない。
+        /// また元の報酬はこのアプリからは削除できないので、後始末はWeb画面でユーザーが行う。
+        /// </summary>
+        /// <param name="source">コピー元の報酬</param>
+        /// <param name="suffix">タイトルへ付ける接尾辞</param>
+        /// <returns>コピー結果</returns>
+        public static async Task<ChannelPointCopyResult> CopyRewardAsync(ChannelPointRewardForm source, string suffix)
+        {
+            var lastErrorMessage = "";
+
+            // タイトル重複だけは接尾辞を重ねて再試行する（例: 「報酬'」→「報酬''」）
+            for (var attempt = 1; attempt <= COPY_RETRY_COUNT; attempt++)
+            {
+                var candidateSuffix = string.Concat(Enumerable.Repeat(suffix, attempt));
+                var title = BuildCopyTitle(source.Title, candidateSuffix);
+
+                var result = await TwitchHelper.CreateCustomRewardAsync(BuildCreateRequest(source, title));
+
+                if (result.IsSuccess)
+                {
+                    return new ChannelPointCopyResult
+                    {
+                        IsSuccess = true,
+                        SourceTitle = source.Title,
+                        CreatedTitle = title
+                    };
+                }
+
+                lastErrorMessage = result.ErrorMessage;
+
+                // 重複以外の失敗は再試行しても同じなので即座に打ち切る
+                if (result.ErrorKind != TwitchApiErrorKind.DuplicateTitle) break;
+            }
+
+            return new ChannelPointCopyResult
+            {
+                IsSuccess = false,
+                SourceTitle = source.Title,
+                ErrorMessage = lastErrorMessage
+            };
+        }
+
+
+        /// <summary>
+        /// コピー先のタイトルを組み立てる。
+        /// Twitchの上限（45文字）を超える場合は元のタイトル側を切り詰める。
+        /// </summary>
+        /// <param name="sourceTitle">コピー元の報酬名</param>
+        /// <param name="suffix">付与する接尾辞</param>
+        /// <returns>コピー先の報酬名</returns>
+        private static string BuildCopyTitle(string sourceTitle, string suffix)
+        {
+            var maxBaseLength = TITLE_MAX_LENGTH - suffix.Length;
+
+            // 接尾辞だけで上限を超えるような設定値の場合は、上限まで切り詰めて返すしかない
+            if (maxBaseLength <= 0) return suffix[..TITLE_MAX_LENGTH];
+
+            var baseTitle = sourceTitle.Length > maxBaseLength
+                ? sourceTitle[..maxBaseLength]
+                : sourceTitle;
+
+            return baseTitle + suffix;
+        }
+
+
+        /// <summary>
+        /// コピー元の設定を作成リクエストへ写す（画像はAPIで設定できないため対象外）
+        /// </summary>
+        /// <param name="source">コピー元の報酬</param>
+        /// <param name="title">コピー先の報酬名</param>
+        /// <returns>作成リクエスト</returns>
+        private static CreateCustomRewardsRequest BuildCreateRequest(ChannelPointRewardForm source, string title)
+        {
+            var request = new CreateCustomRewardsRequest
+            {
+                Title = title,
+                Cost = source.Cost,
+                Prompt = source.Prompt,
+                IsEnabled = source.IsEnabled,
+                IsUserInputRequired = source.IsUserInputRequired,
+                ShouldRedemptionsSkipRequestQueue = source.ShouldRedemptionsSkipQueue,
+
+                // 上限・クールダウンは「有効フラグ＋値」の組で送る。0は未設定とみなす
+                IsMaxPerStreamEnabled = source.MaxPerStream > 0,
+                MaxPerStream = source.MaxPerStream > 0 ? source.MaxPerStream : null,
+
+                IsMaxPerUserPerStreamEnabled = source.MaxPerUserPerStream > 0,
+                MaxPerUserPerStream = source.MaxPerUserPerStream > 0 ? source.MaxPerUserPerStream : null,
+
+                IsGlobalCooldownEnabled = source.GlobalCooldownSeconds > 0,
+                GlobalCooldownSeconds = source.GlobalCooldownSeconds > 0 ? source.GlobalCooldownSeconds : null,
+            };
+
+            // 背景色は未設定のまま送るとエラーになり得るため、値があるときだけ設定する
+            if (!string.IsNullOrWhiteSpace(source.BackgroundColor))
+            {
+                request.BackgroundColor = source.BackgroundColor;
+            }
+
+            return request;
+        }
+
+        #endregion
+
+
+        #region ==================== 詰め替え ====================
 
         /// <summary>
         /// TwitchLibのCustomRewardを画面用DTOへ詰め替える
@@ -148,5 +324,7 @@ namespace JTSA.Utility
             form.IsEnabled = reward.IsEnabled;
             form.IsPaused = reward.IsPaused;
         }
+
+        #endregion
     }
 }

--- a/JTSA/Utility/TwitchApiResult.cs
+++ b/JTSA/Utility/TwitchApiResult.cs
@@ -1,0 +1,155 @@
+namespace JTSA.Utility
+{
+    /// <summary>
+    /// Twitch API 呼び出しの失敗理由の分類
+    /// </summary>
+    public enum TwitchApiErrorKind
+    {
+        /// <summary> 分類できない失敗 </summary>
+        Unknown = 0,
+
+        /// <summary> API を叩く前の問題（broadcaster_id 未設定など） </summary>
+        NotConfigured,
+
+        /// <summary> 403：このアプリが作成した報酬ではないため操作できない </summary>
+        NotManageable,
+
+        /// <summary> 400：同名の報酬が既に存在する </summary>
+        DuplicateTitle,
+
+        /// <summary> 400：その他のリクエスト不正 </summary>
+        InvalidRequest,
+
+        /// <summary> 401：スコープ不足・トークン期限切れ </summary>
+        Unauthorized,
+
+        /// <summary> 429：レート制限 </summary>
+        RateLimited,
+    }
+
+
+    /// <summary>
+    /// Twitch API 呼び出しの結果。
+    ///
+    /// 既存の TwitchHelper は例外を握り潰して null を返すため、
+    /// 呼び出し側が「なぜ失敗したか」を画面に出せない。
+    /// 報酬のコピー処理はタイトル重複を検知して接尾辞を変えて再試行する必要があるため、
+    /// チャンネルポイント関連ではこの型で失敗理由を返す。
+    /// </summary>
+    /// <typeparam name="T">成功時のデータ型</typeparam>
+    public class TwitchApiResult<T>
+    {
+        /// <summary> 成功したか </summary>
+        public bool IsSuccess { get; private init; }
+
+        /// <summary> 成功時のデータ </summary>
+        public T? Data { get; private init; }
+
+        /// <summary> 失敗理由の分類 </summary>
+        public TwitchApiErrorKind ErrorKind { get; private init; }
+
+        /// <summary> 画面・ログに出すための失敗理由 </summary>
+        public string ErrorMessage { get; private init; } = "";
+
+
+        public static TwitchApiResult<T> Success(T data)
+            => new() { IsSuccess = true, Data = data };
+
+
+        public static TwitchApiResult<T> Failure(TwitchApiErrorKind kind, string message)
+            => new() { IsSuccess = false, ErrorKind = kind, ErrorMessage = message };
+
+
+        /// <summary>
+        /// TwitchLib が投げた例外を失敗理由へ分類する。
+        /// TwitchLib は HTTP ステータスごとに専用の例外型を投げ、
+        /// メッセージにレスポンスボディ（Twitch のエラーコード文字列）を含めてくる。
+        /// </summary>
+        /// <param name="ex">TwitchLib が投げた例外</param>
+        /// <returns>分類済みの失敗結果</returns>
+        public static TwitchApiResult<T> FromException(Exception ex)
+        {
+            var message = ex.Message ?? "";
+
+            // 例外の型名で判定する（TwitchLib.Api.Core.Exceptions 配下）
+            var kind = ex.GetType().Name switch
+            {
+                "BadScopeException" => TwitchApiErrorKind.Unauthorized,
+                "BadTokenException" => TwitchApiErrorKind.Unauthorized,
+                "TokenExpiredException" => TwitchApiErrorKind.Unauthorized,
+                "InvalidCredentialException" => TwitchApiErrorKind.Unauthorized,
+                "TooManyRequestsException" => TwitchApiErrorKind.RateLimited,
+                "BadRequestException" => ClassifyBadRequest(message),
+                "BadParameterException" => ClassifyBadRequest(message),
+                _ => ClassifyByMessage(message),
+            };
+
+            return Failure(kind, ToUserMessage(kind, message));
+        }
+
+
+        /// <summary>
+        /// 400 系のうち、タイトル重複だけは呼び出し側がリトライできるよう区別する
+        /// </summary>
+        private static TwitchApiErrorKind ClassifyBadRequest(string message)
+        {
+            return IsDuplicateTitle(message)
+                ? TwitchApiErrorKind.DuplicateTitle
+                : TwitchApiErrorKind.InvalidRequest;
+        }
+
+
+        /// <summary>
+        /// 専用の例外型に該当しない場合、メッセージ本文から推測する
+        /// </summary>
+        private static TwitchApiErrorKind ClassifyByMessage(string message)
+        {
+            if (IsDuplicateTitle(message)) return TwitchApiErrorKind.DuplicateTitle;
+
+            if (message.Contains("403") || message.Contains("Forbidden", StringComparison.OrdinalIgnoreCase))
+                return TwitchApiErrorKind.NotManageable;
+
+            if (message.Contains("401") || message.Contains("Unauthorized", StringComparison.OrdinalIgnoreCase))
+                return TwitchApiErrorKind.Unauthorized;
+
+            if (message.Contains("429")) return TwitchApiErrorKind.RateLimited;
+
+            return TwitchApiErrorKind.Unknown;
+        }
+
+
+        /// <summary>
+        /// Twitch はタイトル重複時に CREATE_CUSTOM_REWARD_DUPLICATE_REWARD を返す
+        /// </summary>
+        private static bool IsDuplicateTitle(string message)
+        {
+            return message.Contains("DUPLICATE", StringComparison.OrdinalIgnoreCase);
+        }
+
+
+        /// <summary>
+        /// 分類結果を日本語の説明文にする（元のメッセージも診断用に添える）
+        /// </summary>
+        private static string ToUserMessage(TwitchApiErrorKind kind, string rawMessage)
+        {
+            var summary = kind switch
+            {
+                TwitchApiErrorKind.NotManageable
+                    => "この報酬は Twitch の Web 画面（または他アプリ）から作成されたため、このアプリからは操作できません。",
+                TwitchApiErrorKind.DuplicateTitle
+                    => "同じ名前の報酬が既に存在します。",
+                TwitchApiErrorKind.InvalidRequest
+                    => "リクエストの内容が不正です。",
+                TwitchApiErrorKind.Unauthorized
+                    => "認証が切れているか、権限（スコープ）が不足しています。再認証してください。",
+                TwitchApiErrorKind.RateLimited
+                    => "Twitch の API 制限に達しました。しばらく待ってから再試行してください。",
+                TwitchApiErrorKind.NotConfigured
+                    => "配信者情報が未取得のため実行できません。",
+                _ => "不明なエラーが発生しました。",
+            };
+
+            return string.IsNullOrWhiteSpace(rawMessage) ? summary : $"{summary}（{rawMessage}）";
+        }
+    }
+}

--- a/JTSA/Utility/TwitchHelper.cs
+++ b/JTSA/Utility/TwitchHelper.cs
@@ -409,8 +409,12 @@ namespace JTSA.Utility
         /// API: GET https://api.twitch.tv/helix/channel_points/custom_rewards
         /// Scope: channel:read:redemptions
         /// </summary>
+        /// <param name="onlyManageableRewards">
+        /// trueの場合、このアプリ（同一client_id）が作成した報酬のみを返す。
+        /// falseの結果との差分がTwitchのWeb画面や他アプリで作成された「操作不可」な報酬になる。
+        /// </param>
         /// <returns>TwitchLibのCustomReward型のリスト。失敗した場合はnull。</returns>
-        public static async Task<List<CustomReward>?> GetCustomRewardsAsync()
+        public static async Task<List<CustomReward>?> GetCustomRewardsAsync(bool onlyManageableRewards = false)
         {
             MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
             mainWindow.AppLogPanel.ProcessStart(nameof(TwitchHelper), "TwitchLibでチャンネルポイントリスト取得");
@@ -425,7 +429,7 @@ namespace JTSA.Utility
             {
                 var response = await api.Helix.ChannelPoints.GetCustomRewardAsync(
                     broadcasterId: TwitchHelper.BroadcasterId,
-                    onlyManageableRewards: false
+                    onlyManageableRewards: onlyManageableRewards
                 );
 
                 if (response?.Data != null)

--- a/JTSA/Utility/TwitchHelper.cs
+++ b/JTSA/Utility/TwitchHelper.cs
@@ -34,6 +34,46 @@ namespace JTSA.Utility
 
 
         /// <summary>
+        /// アクセストークンの持ち主（＝このアプリを認証したユーザー本人）の情報を取得する。
+        /// API: GET https://api.twitch.tv/helix/users （ids/loginsを指定しない場合はトークンの本人が返る）
+        ///
+        /// ユーザー名を手入力させずに配信者IDを特定するために使う。
+        /// </summary>
+        /// <returns>認証中ユーザーの情報。失敗した場合はnull。</returns>
+        public static async Task<TwitchUserIF?> GetAuthenticatedUserAsync()
+        {
+            try
+            {
+                // ids/logins を指定しない場合、アクセストークンの持ち主が返る
+                var apiResponse = await api.Helix.Users.GetUsersAsync();
+
+                var responseData = apiResponse?.Users?.FirstOrDefault();
+                if (responseData == null) return null;
+
+                return new TwitchUserIF()
+                {
+                    UserId = responseData.Id,
+                    Login = responseData.Login,
+                    BroadcasterType = responseData.BroadcasterType,
+                    CreatedAt = responseData.CreatedAt,
+                    DisplayName = responseData.DisplayName,
+                    Description = responseData.Description,
+                    OfflineImageUrl = responseData.OfflineImageUrl,
+                    ProfileImageUrl = responseData.ProfileImageUrl,
+                    UserType = responseData.Type,
+                };
+            }
+            catch (Exception ex)
+            {
+                MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
+                mainWindow.AppLogPanel.Error(nameof(TwitchHelper), "認証ユーザー情報の取得失敗：" + ex.Message);
+            }
+
+            return null;
+        }
+
+
+        /// <summary>
         /// 配信者情報取得処理
         /// </summary>
         /// <param name="userName"></param>
@@ -453,9 +493,9 @@ namespace JTSA.Utility
         /// </summary>
         /// <param name="CustomRewardId">修正対象のカスタムリワードID</param>
         /// <param name="updateCustomRewardRequest">修正内容</param>
-        /// <returns>修正後のカスタム報酬リスト(修正したものだけ)。失敗した場合はnull。</returns>
-        public static async Task<List<CustomReward>?> UpdateCustomRewardAsync(
-            string CustomRewardId, 
+        /// <returns>修正後のカスタム報酬リスト(修正したものだけ)。失敗理由付き。</returns>
+        public static async Task<TwitchApiResult<List<CustomReward>>> UpdateCustomRewardAsync(
+            string CustomRewardId,
             UpdateCustomRewardRequest updateCustomRewardRequest)
         {
             MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
@@ -464,7 +504,8 @@ namespace JTSA.Utility
             if (string.IsNullOrEmpty(TwitchHelper.BroadcasterId))
             {
                 mainWindow.AppLogPanel.Error(nameof(TwitchHelper), "TwitchLibでチャンネルポイント報酬更新中断:broadcaster_id 不詳");
-                return null;
+                return TwitchApiResult<List<CustomReward>>.Failure(
+                    TwitchApiErrorKind.NotConfigured, "broadcaster_id 不詳");
             }
             api.Settings.AccessToken = TwitchHelper.api.Settings.AccessToken;
             api.Settings.ClientId = TwitchHelper.ClientID; // ClientIdを明示的に再セット
@@ -480,15 +521,59 @@ namespace JTSA.Utility
                 if (response?.Data != null)
                 {
                     mainWindow.AppLogPanel.ProcessEnd(nameof(TwitchHelper), "TwitchLibでチャンネルポイント報酬更新");
-                    return response.Data.ToList();
+                    return TwitchApiResult<List<CustomReward>>.Success(response.Data.ToList());
                 }
+
+                return TwitchApiResult<List<CustomReward>>.Failure(
+                    TwitchApiErrorKind.Unknown, "レスポンスが空でした");
             }
             catch (Exception ex)
             {
-                mainWindow.AppLogPanel.Error(nameof(TwitchHelper), "TwitchLibでチャンネルポイント報酬更新失敗:" + ex.Message);
+                var result = TwitchApiResult<List<CustomReward>>.FromException(ex);
+                mainWindow.AppLogPanel.Error(nameof(TwitchHelper), "TwitchLibでチャンネルポイント報酬更新失敗:" + result.ErrorMessage);
+                return result;
             }
+        }
 
-            return null;
+
+        /// <summary>
+        /// TwitchLibを使用してチャンネルポイントのカスタム報酬を削除する
+        /// API: DELETE https://api.twitch.tv/helix/channel_points/custom_rewards
+        /// Scope: channel:manage:redemptions
+        ///
+        /// このアプリ（同一client_id）が作成した報酬しか削除できない点に注意。
+        /// </summary>
+        /// <param name="customRewardId">削除対象のカスタムリワードID</param>
+        /// <returns>成否と失敗理由</returns>
+        public static async Task<TwitchApiResult<bool>> DeleteCustomRewardAsync(string customRewardId)
+        {
+            MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
+            var appLogProcessName = mainWindow.AppLogPanel.ProcessStart(nameof(TwitchHelper), "TwitchLibでチャンネルポイント報酬削除");
+
+            if (string.IsNullOrEmpty(TwitchHelper.BroadcasterId))
+            {
+                mainWindow.AppLogPanel.Error(nameof(TwitchHelper), "TwitchLibでチャンネルポイント報酬削除中断:broadcaster_id 不詳");
+                return TwitchApiResult<bool>.Failure(TwitchApiErrorKind.NotConfigured, "broadcaster_id 不詳");
+            }
+            api.Settings.AccessToken = TwitchHelper.api.Settings.AccessToken;
+            api.Settings.ClientId = TwitchHelper.ClientID; // ClientIdを明示的に再セット
+
+            try
+            {
+                await api.Helix.ChannelPoints.DeleteCustomRewardAsync(
+                    broadcasterId: TwitchHelper.BroadcasterId,
+                    rewardId: customRewardId
+                );
+
+                mainWindow.AppLogPanel.ProcessEnd(nameof(TwitchHelper), appLogProcessName);
+                return TwitchApiResult<bool>.Success(true);
+            }
+            catch (Exception ex)
+            {
+                var result = TwitchApiResult<bool>.FromException(ex);
+                mainWindow.AppLogPanel.Error(nameof(TwitchHelper), "TwitchLibでチャンネルポイント報酬削除失敗:" + result.ErrorMessage);
+                return result;
+            }
         }
 
 
@@ -498,8 +583,8 @@ namespace JTSA.Utility
         /// Scope: channel:manage:redemptions
         /// </summary>
         /// <param name="createCustomRewardRequest">作成内容</param>
-        /// <returns>作成後のカスタム報酬リスト（作成したものだけ）。失敗した場合はnull。</returns>
-        public static async Task<List<CustomReward>?> CreateCustomRewardAsync(CreateCustomRewardsRequest createCustomRewardRequest)
+        /// <returns>作成後のカスタム報酬リスト（作成したものだけ）。失敗理由付き。</returns>
+        public static async Task<TwitchApiResult<List<CustomReward>>> CreateCustomRewardAsync(CreateCustomRewardsRequest createCustomRewardRequest)
         {
             MainWindow mainWindow = (MainWindow)Application.Current.MainWindow;
             var appLogProcessName = mainWindow.AppLogPanel.ProcessStart(nameof(TwitchHelper), "TwitchLibでチャンネルポイント報酬作成");
@@ -507,7 +592,8 @@ namespace JTSA.Utility
             if (string.IsNullOrEmpty(TwitchHelper.BroadcasterId))
             {
                 mainWindow.AppLogPanel.Error(nameof(TwitchHelper), "broadcaster_id 不詳");
-                return null;
+                return TwitchApiResult<List<CustomReward>>.Failure(
+                    TwitchApiErrorKind.NotConfigured, "broadcaster_id 不詳");
             }
             api.Settings.AccessToken = TwitchHelper.api.Settings.AccessToken;
             api.Settings.ClientId = TwitchHelper.ClientID; // ClientIdを明示的に再セット
@@ -522,15 +608,18 @@ namespace JTSA.Utility
                 if (response?.Data != null)
                 {
                     mainWindow.AppLogPanel.ProcessEnd(nameof(TwitchHelper), appLogProcessName);
-                    return response.Data.ToList();
+                    return TwitchApiResult<List<CustomReward>>.Success(response.Data.ToList());
                 }
+
+                return TwitchApiResult<List<CustomReward>>.Failure(
+                    TwitchApiErrorKind.Unknown, "レスポンスが空でした");
             }
             catch (Exception ex)
             {
-                mainWindow.AppLogPanel.Error(nameof(TwitchHelper), "TwitchLibでチャンネルポイント報酬作成失敗：" + ex.Message);
+                var result = TwitchApiResult<List<CustomReward>>.FromException(ex);
+                mainWindow.AppLogPanel.Error(nameof(TwitchHelper), "TwitchLibでチャンネルポイント報酬作成失敗：" + result.ErrorMessage);
+                return result;
             }
-
-            return null;
         }
 
         #endregion

--- a/docs/CHANNELPOINT-SYSTEM-TASKS.md
+++ b/docs/CHANNELPOINT-SYSTEM-TASKS.md
@@ -1,0 +1,86 @@
+# チャンネルポイント管理システム — タスク分割と実行記録
+
+> 対象ブランチ: `feature/manage-channelpoint`（`develop` から分岐）
+> 起点コミット: `90f988d`
+> 作業開始: 2026-08-09
+
+## 1. 概要
+
+### 目的
+
+JTSA の CP タブ（`ChannelPointPanel`）を実用に足る管理画面へ整備する。
+
+1. **既存の壊れている部分を直す** — 一覧が一度も読み込まれない、一時停止トグルが別の行を更新する、等
+2. **操作不可な報酬をアプリ管理下へコピーする導線を作る** — Twitch Web 画面から作った報酬は OAuth アプリから操作できないため
+3. **プリセット機能** — 報酬 ON/OFF の組み合わせを保存し、ワンクリックで切り替える。カテゴリに紐づけて自動適用も行う
+
+### 決定事項
+
+| 論点 | 決定 |
+|---|---|
+| コピー時のタイトル重複回避 | 接尾辞に `'`（シングルクオート）を付ける。設定で変更可 |
+| プリセットの ON/OFF | `IsEnabled`（有効/無効）で切り替える。`IsPaused` はプリセット対象外 |
+| プリセット未登録の報酬 | **全件スナップショット方式**。保存時に「操作可能な全報酬」の `IsEnabled` をまとめて記録し、適用時は全件をその状態に戻す |
+| 適用タイミング | CP タブの手動ボタン ＋ カテゴリに紐づけての自動適用。カテゴリにプリセット指定が無ければ**何もしない** |
+
+### Twitch API の制約（設計の前提・検証済み）
+
+- `GET /channel_points/custom_rewards` の `only_manageable_rewards=true` は「自分の client_id が作成した報酬」のみを返す。**`false` の結果との差分＝Web/他アプリ作成分＝操作不可**。これが「操作可能」列の判定ロジック。
+- **画像は作成/更新 API で指定できない**（Twitch 公式 UI のみ）。コピー先は既定アイコンになる。
+- **タイトルはチャンネル内で一意**、最大 45 文字。接尾辞付与時は 45 文字を超えないよう元タイトル側を切り詰める。
+- **操作不可な報酬はアプリから削除できない**。コピー後の元報酬の始末は Web UI 側でユーザーが行う。
+- TwitchLib 3.10.1-preview で使えるプロパティ（reflection で確認済み）:
+  - `CustomReward`: `Id / Title / Prompt / Cost / Image / BackgroundColor / IsEnabled / IsUserInputRequired / MaxPerStreamSetting / MaxPerUserPerStreamSetting / GlobalCooldownSetting / IsPaused / IsInStock / ShouldRedemptionsSkipQueue`
+  - `CreateCustomRewardsRequest` / `UpdateCustomRewardRequest`: 上記のうち画像以外すべて設定可能
+  - `api.Helix.ChannelPoints.DeleteCustomRewardAsync` も利用可能
+
+## 2. タスク一覧
+
+### Phase 0 — ブランチ準備
+
+- [x] P0-1 `develop` を `origin/develop` まで最新化
+- [x] P0-2 `feature/manage-channelpoint` ブランチ作成
+- [x] P0-3 本ドキュメント作成
+
+### Phase 1 — 土台整備と既存バグ修正
+
+- [x] P1-1 `Forms/ChannelPointRewardForm.cs` 新規作成（INotifyPropertyChanged 実装）
+- [x] P1-2 `TwitchHelper.GetCustomRewardsAsync` に `onlyManageableRewards` 引数を追加
+- [x] P1-3 `Utility/ChannelPointService.cs` 新規作成（`FetchRewardsAsync` — manageable 差分で操作可否を判定）
+- [x] P1-4 `ChannelPointPanel` を `ObservableCollection<ChannelPointRewardForm>` バインドへ移行（`_cachedRewards` 廃止）
+- [x] P1-5 「操作可能」列の DataTemplate 実装（✔ / 🔒 ＋ ToolTip）と、操作不可行のトグル無効化
+- [x] P1-6 `Initialize()` 新設 ＋ `MainWindow_LoadedAsync` から呼び出し ＋ 手動更新ボタン追加
+- [x] P1-7 バグ修正: 一時停止トグルが `SelectedItem` 基準で別行を更新する問題
+- [x] P1-8 バグ修正: 一時停止トグル後にキャッシュを更新せず古い状態を再表示する問題
+- [x] P1-9 バグ修正: `Mode=OneWay` バインドのチェックボックスをクリックするとバインドが外れる問題（TwoWay ＋ 失敗時ロールバックへ変更）
+- [x] P1-10 ビルド確認
+- [ ] P1-11 実機動作確認
+
+### Phase 2 — 報酬コピー機能
+
+（Phase 1 完了時に具体化する）
+
+### Phase 3 — プリセット機能
+
+（Phase 2 完了時に具体化する）
+
+### Phase 4 — カテゴリ紐づけ自動適用
+
+（Phase 3 完了時に具体化する）
+
+## 3. 実行ログ
+
+| 日付 | タスクID | 内容 | 変更ファイル | コミット | 動作確認 |
+|---|---|---|---|---|---|
+| 2026-08-09 | P0-1〜3 | develop 最新化、feature ブランチ作成、本ドキュメント作成 | `docs/CHANNELPOINT-SYSTEM-TASKS.md` | — | 対象なし |
+| 2026-08-09 | P1-1〜10 | 土台整備（Form/Service 追加）と既存バグ 3 件の修正 | `Forms/ChannelPointRewardForm.cs`(新), `Utility/ChannelPointService.cs`(新), `Utility/TwitchHelper.cs`, `Panels/ChannelPointPanel.xaml(.cs)`, `MainWindow.xaml.cs` | — | `dotnet build` 成功（0 エラー／新規ファイルの警告なし）。**実機動作は未検証** |
+
+## 4. 課題・保留
+
+| # | 内容 | 状態 |
+|---|---|---|
+| 1 | 報酬タイトルに `'`（シングルクオート）が使えるかは実機未検証。使えない場合は接尾辞を別文字（例 `*` や `_`）へ切り替えられるよう、設定値（`SettingName.ChannelPointCopySuffix`）で持たせる | 未検証 |
+| 2 | コピー後の元報酬（操作不可）はアプリから削除できないため、Web UI での無効化/削除をユーザーに案内する必要がある | 設計に反映済み |
+| 3 | `DAO_GamePlaylist.InsertUpdate(header, items)` に既存アイテム削除の未実装バグがある（本改修の対象外だが、プリセット DAO で同じ実装を真似しないこと） | 別課題として放置 |
+| 4 | `only_manageable_rewards=true` の GET に失敗した場合、操作可否が判定できない。安全側に倒して**全件を操作不可**として表示する仕様にした（誤操作で 403 を踏むより良いと判断） | 仕様として確定 |
+| 5 | Phase 1 時点では新規作成フォームは名前・コストのみ（従来どおり）。Prompt・背景色・クールダウン等の入力は Phase 2 でコピー機能と共用する形で追加する | Phase 2 で対応 |

--- a/docs/CHANNELPOINT-SYSTEM-TASKS.md
+++ b/docs/CHANNELPOINT-SYSTEM-TASKS.md
@@ -56,9 +56,28 @@ JTSA の CP タブ（`ChannelPointPanel`）を実用に足る管理画面へ整�
 - [x] P1-10 ビルド確認
 - [ ] P1-11 実機動作確認
 
+### Phase 1.5 — OAuth 認証まわりの緊急修正（計画外・実機検証の前提として追加）
+
+Phase 1 の動作確認でアプリを起動したところ、OAuth 認証直後に NullReferenceException で強制終了した。
+CP タブの初期化まで到達できず検証不能だったため、ユーザー判断のうえこのブランチで修正した。
+
+- [x] P1.5-1 `OAuthButton_Click` に認証後の初期化処理が無く落ちる問題を修正（`InitializeAfterAuthAsync` へ共通化）
+- [x] P1.5-2 `accessTokenResponse` / `deviceCodeResponse` が null でも参照していた箇所に null チェックを追加
+- [x] P1.5-3 `StreamerDataSet` の null 参照 2 箇所を修正（`streamInfo` が null、未登録カテゴリで `dbCategoryData` が null のまま代入）
+- [x] P1.5-4 Twitch ユーザー名の手入力を廃止（`TwitchHelper.GetAuthenticatedUserAsync` でアクセストークンから特定）
+- [x] P1.5-5 デバイスコード認証 URL に `user_code` としてログイン名を連結していた誤りを修正（`verification_uri_complete` を使用）
+
 ### Phase 2 — 報酬コピー機能
 
-（Phase 1 完了時に具体化する）
+- [x] P2-1 `Utility/TwitchApiResult.cs` 新規作成（失敗理由を分類して呼び出し元へ返す）
+- [x] P2-2 `TwitchHelper` の作成/更新を `TwitchApiResult` 返却へ変更、`DeleteCustomRewardAsync` を追加
+- [x] P2-3 `SettingName.ChannelPointCopySuffix = 10` を追加（既定値 `'`）
+- [x] P2-4 `ChannelPointService.CopyRewardAsync`（45 文字制限・重複時の接尾辞リトライ・画像以外の全項目引き継ぎ）
+- [x] P2-5 一覧に「選択」チェック列と行内「コピー」ボタン列を追加、ツールバーに「選択をコピー」を追加
+- [x] P2-6 コピー結果ダイアログ（画像とコピー元の後始末を案内）と「Twitchの報酬設定を開く」ボタン
+- [x] P2-7 トグル失敗時に理由（403/400 等）をダイアログとログに表示
+- [x] P2-8 ビルド確認
+- [ ] P2-9 実機動作確認
 
 ### Phase 3 — プリセット機能
 
@@ -73,7 +92,9 @@ JTSA の CP タブ（`ChannelPointPanel`）を実用に足る管理画面へ整�
 | 日付 | タスクID | 内容 | 変更ファイル | コミット | 動作確認 |
 |---|---|---|---|---|---|
 | 2026-08-09 | P0-1〜3 | develop 最新化、feature ブランチ作成、本ドキュメント作成 | `docs/CHANNELPOINT-SYSTEM-TASKS.md` | — | 対象なし |
-| 2026-08-09 | P1-1〜10 | 土台整備（Form/Service 追加）と既存バグ 3 件の修正 | `Forms/ChannelPointRewardForm.cs`(新), `Utility/ChannelPointService.cs`(新), `Utility/TwitchHelper.cs`, `Panels/ChannelPointPanel.xaml(.cs)`, `MainWindow.xaml.cs` | — | `dotnet build` 成功（0 エラー／新規ファイルの警告なし）。**実機動作は未検証** |
+| 2026-08-09 | P1-1〜10 | 土台整備（Form/Service 追加）と既存バグ 3 件の修正 | `Forms/ChannelPointRewardForm.cs`(新), `Utility/ChannelPointService.cs`(新), `Utility/TwitchHelper.cs`, `Panels/ChannelPointPanel.xaml(.cs)`, `MainWindow.xaml.cs` | `3bc99c5` | `dotnet build` 成功（0 エラー／新規ファイルの警告なし）。**実機動作は未検証** |
+| 2026-08-09 | P1.5-1〜5 | Phase 1 の実機確認で OAuth 認証直後のクラッシュが発覚し修正。合わせてユーザー名の手入力を廃止 | `MainWindow.xaml(.cs)`, `Utility/TwitchHelper.cs` | — | `dotnet build` 成功（0 エラー）。**実機動作は未検証** |
+| 2026-08-09 | P2-1〜8 | 報酬コピー機能と API エラー理由の伝播 | `Utility/TwitchApiResult.cs`(新), `Utility/ChannelPointService.cs`, `Utility/TwitchHelper.cs`, `Dao/DAO_Setting.cs`, `Forms/ChannelPointRewardForm.cs`, `Panels/ChannelPointPanel.xaml(.cs)` | — | `dotnet build` 成功（0 エラー）。**実機動作は未検証** |
 
 ## 4. 課題・保留
 
@@ -83,4 +104,6 @@ JTSA の CP タブ（`ChannelPointPanel`）を実用に足る管理画面へ整�
 | 2 | コピー後の元報酬（操作不可）はアプリから削除できないため、Web UI での無効化/削除をユーザーに案内する必要がある | 設計に反映済み |
 | 3 | `DAO_GamePlaylist.InsertUpdate(header, items)` に既存アイテム削除の未実装バグがある（本改修の対象外だが、プリセット DAO で同じ実装を真似しないこと） | 別課題として放置 |
 | 4 | `only_manageable_rewards=true` の GET に失敗した場合、操作可否が判定できない。安全側に倒して**全件を操作不可**として表示する仕様にした（誤操作で 403 を踏むより良いと判断） | 仕様として確定 |
-| 5 | Phase 1 時点では新規作成フォームは名前・コストのみ（従来どおり）。Prompt・背景色・クールダウン等の入力は Phase 2 でコピー機能と共用する形で追加する | Phase 2 で対応 |
+| 5 | 新規作成フォームは名前・コストのみのまま。Prompt・背景色・クールダウン等はコピー機能では引き継ぐが、手動作成時の入力欄は未実装 | 未対応（優先度低） |
+| 6 | `SettingName.UserName` は表示と Twitch ダッシュボード URL 用にのみ使う値になった（認証の前提条件ではなくなり、アクセストークンから毎回上書きされる） | 仕様変更として確定 |
+| 7 | `TwitchHelper.GetBroadcasterIdAsync(userName)` は起動経路からは呼ばれなくなったが、FriendPanel / ChatPanel が他ユーザーの情報取得に使っているため残す | 確認済み・残置 |

--- a/docs/CHANNELPOINT-SYSTEM-TASKS.md
+++ b/docs/CHANNELPOINT-SYSTEM-TASKS.md
@@ -54,7 +54,8 @@ JTSA の CP タブ（`ChannelPointPanel`）を実用に足る管理画面へ整�
 - [x] P1-8 バグ修正: 一時停止トグル後にキャッシュを更新せず古い状態を再表示する問題
 - [x] P1-9 バグ修正: `Mode=OneWay` バインドのチェックボックスをクリックするとバインドが外れる問題（TwoWay ＋ 失敗時ロールバックへ変更）
 - [x] P1-10 ビルド確認
-- [ ] P1-11 実機動作確認
+- [x] P1-11 実機動作確認（一覧取得まで。DB に 29 件の報酬キャッシュを確認）
+- [x] P1-12 操作可否の判定失敗と「本当に操作可能 0 件」を画面上で区別できるように（判定失敗時は警告文を出す）
 
 ### Phase 1.5 — OAuth 認証まわりの緊急修正（計画外・実機検証の前提として追加）
 
@@ -116,7 +117,9 @@ CP タブの初期化まで到達できず検証不能だったため、ユー�
 | 2026-08-09 | P1.5-1〜5 | Phase 1 の実機確認で OAuth 認証直後のクラッシュが発覚し修正。合わせてユーザー名の手入力を廃止 | `MainWindow.xaml(.cs)`, `Utility/TwitchHelper.cs` | — | `dotnet build` 成功（0 エラー）。**実機動作は未検証** |
 | 2026-08-09 | P2-1〜8 | 報酬コピー機能と API エラー理由の伝播 | `Utility/TwitchApiResult.cs`(新), `Utility/ChannelPointService.cs`, `Utility/TwitchHelper.cs`, `Dao/DAO_Setting.cs`, `Forms/ChannelPointRewardForm.cs`, `Panels/ChannelPointPanel.xaml(.cs)` | `d687645` | `dotnet build` 成功（0 エラー）。**実機動作は未検証** |
 | 2026-08-09 | P3-1〜8 | プリセット機能（モデル・マイグレーション・DAO・保存/適用・UI） | `Models/M_ChannelPoint.cs`(新), `Models/T_ChannelPointPreset*.cs`(新), `AppDbContext.cs`, `Migrations/`(新), `Dao/DAO_ChannelPoint*.cs`(新), `Forms/ChannelPointPresetForm.cs`(新), `Utility/ChannelPointService.cs`, `Panels/ChannelPointPanel.xaml(.cs)` | — | `dotnet build` 成功（0 エラー）。**実機動作は未検証** |
-| 2026-08-09 | P4-1〜8 | カテゴリ紐づけと自動適用 | `Forms/CategoryForm.cs`, `Panels/CategoryPanel.xaml(.cs)`, `Panels/PlayingGamePanel.xaml.cs`, `MainWindow.xaml.cs`, `Dao/DAO_Category.cs`, `Dao/DAO_ChannelPointPreset.cs` | — | `dotnet build` 成功（0 エラー）。**実機動作は未検証** |
+| 2026-08-09 | P4-1〜8 | カテゴリ紐づけと自動適用 | `Forms/CategoryForm.cs`, `Panels/CategoryPanel.xaml(.cs)`, `Panels/PlayingGamePanel.xaml.cs`, `MainWindow.xaml.cs`, `Dao/DAO_Category.cs`, `Dao/DAO_ChannelPointPreset.cs` | `ae8789e` | `dotnet build` 成功（0 エラー）。**実機動作は未検証** |
+| 2026-08-09 | P1-11 | 実機起動による確認（DB をバックアップのうえ実施） | — | — | **成功**: 異常終了なし（前回は exit 82 で NRE）。マイグレーション `channel_point_preset` 適用済み（既存データ保持）。`M_Setting.UserName=xiphelier` がトークンから自動設定され、ユーザー名入力の廃止が機能。`M_ChannelPoint` に 29 件キャッシュ＝一覧取得が成功。**トグル・コピー・プリセット・カテゴリ連動は未検証** |
+| 2026-08-09 | P1-12 | 実機で「操作可能 0 件」となったため、判定失敗との区別が付くようステータス表示を改善 | `Utility/ChannelPointService.cs`, `Panels/ChannelPointPanel.xaml.cs` | — | `dotnet build` 成功（0 エラー）。**実機動作は未検証** |
 
 ## 4. 課題・保留
 
@@ -133,3 +136,5 @@ CP タブの初期化まで到達できず検証不能だったため、ユー�
 | 9 | `M_ChannelPoint`（報酬キャッシュ）は現状プリセット内訳の「削除済み」判定の補助のみで、実質は報酬一覧の取得結果から判定している。将来オフライン表示が必要になったら活用する | 用途限定 |
 | 10 | プリセット適用は差分のある報酬だけ PATCH する。報酬数が多い場合の Twitch レート制限は未検証 | 未検証 |
 | 11 | `dotnet-ef` 9.0.9 をグローバルツールとして導入した（マイグレーション生成に必要） | 環境構築として実施 |
+| 12 | **実機で 29 件すべてが「操作不可」と判定された。** 全件が Twitch の Web 画面から作成されたのであれば正しい結果だが、`only_manageable_rewards=true` の呼び出しが失敗して安全側に倒れた可能性も残る。P1-12 で両者を画面上で区別できるようにしたので、次回起動時のステータス表示で確定させる | **要確認** |
+| 13 | 操作可能な報酬が 0 件の間はプリセットを 1 つも保存できない（保存対象が操作可能な報酬のみのため）。まずコピーで操作可能な報酬を作る必要がある。ステータス表示でその旨を案内している | 仕様どおり |

--- a/docs/CHANNELPOINT-SYSTEM-TASKS.md
+++ b/docs/CHANNELPOINT-SYSTEM-TASKS.md
@@ -83,9 +83,29 @@ CP タブの初期化まで到達できず検証不能だったため、ユー�
 
 （Phase 2 完了時に具体化する）
 
+### Phase 3 — プリセット機能
+
+- [x] P3-1 モデル 3 つ追加（`M_ChannelPoint` / `T_ChannelPointPresetHeader` / `T_ChannelPointPresetItem`）
+- [x] P3-2 `AppDbContext` に DbSet と複合キー定義を追加、`M_Category.ChannelPointPresetId` を追加
+- [x] P3-3 マイグレーション `20260809075615_channel_point_preset` を生成
+- [x] P3-4 `DAO_ChannelPoint`（キャッシュ同期）と `DAO_ChannelPointPreset`（ヘッダ＋アイテム）を追加
+- [x] P3-5 `Forms/ChannelPointPresetForm.cs`（一覧用＋内訳用）を追加
+- [x] P3-6 `ChannelPointService.SavePreset` / `ApplyPresetAsync`（差分のある報酬だけ更新）
+- [x] P3-7 CP タブにプリセット UI（選択・適用・新規保存・上書き・名前変更・削除・内訳表示）
+- [x] P3-8 ビルド確認
+- [ ] P3-9 実機動作確認
+
 ### Phase 4 — カテゴリ紐づけ自動適用
 
-（Phase 3 完了時に具体化する）
+- [x] P4-1 `CategoryForm.ChannelPointPresetId` を追加（0＝紐づけなし）
+- [x] P4-2 CategoryPanel の各カテゴリ行にプリセット選択 ComboBox を追加し、変更時に保存
+- [x] P4-3 `ChannelPointService.ApplyPresetForCategoryAsync`（紐づけが無ければ無操作）
+- [x] P4-4 `MainWindow.ApplyChannelPointPresetForCategoryAsync` を追加し、タイトル送信後に呼び出し
+- [x] P4-5 PlayingGamePanel の「プレイ中」設定時にも呼び出し
+- [x] P4-6 プリセット削除時にカテゴリからの紐づけも外す（存在しないプリセットを指し続けないため）
+- [x] P4-7 `DAO_Category.SelectAllOrderbyLastUser` の詰め替えに新列を追加（`Update` で紐づけが消えるのを防ぐ）
+- [x] P4-8 ビルド確認
+- [ ] P4-9 実機動作確認
 
 ## 3. 実行ログ
 
@@ -94,7 +114,9 @@ CP タブの初期化まで到達できず検証不能だったため、ユー�
 | 2026-08-09 | P0-1〜3 | develop 最新化、feature ブランチ作成、本ドキュメント作成 | `docs/CHANNELPOINT-SYSTEM-TASKS.md` | — | 対象なし |
 | 2026-08-09 | P1-1〜10 | 土台整備（Form/Service 追加）と既存バグ 3 件の修正 | `Forms/ChannelPointRewardForm.cs`(新), `Utility/ChannelPointService.cs`(新), `Utility/TwitchHelper.cs`, `Panels/ChannelPointPanel.xaml(.cs)`, `MainWindow.xaml.cs` | `3bc99c5` | `dotnet build` 成功（0 エラー／新規ファイルの警告なし）。**実機動作は未検証** |
 | 2026-08-09 | P1.5-1〜5 | Phase 1 の実機確認で OAuth 認証直後のクラッシュが発覚し修正。合わせてユーザー名の手入力を廃止 | `MainWindow.xaml(.cs)`, `Utility/TwitchHelper.cs` | — | `dotnet build` 成功（0 エラー）。**実機動作は未検証** |
-| 2026-08-09 | P2-1〜8 | 報酬コピー機能と API エラー理由の伝播 | `Utility/TwitchApiResult.cs`(新), `Utility/ChannelPointService.cs`, `Utility/TwitchHelper.cs`, `Dao/DAO_Setting.cs`, `Forms/ChannelPointRewardForm.cs`, `Panels/ChannelPointPanel.xaml(.cs)` | — | `dotnet build` 成功（0 エラー）。**実機動作は未検証** |
+| 2026-08-09 | P2-1〜8 | 報酬コピー機能と API エラー理由の伝播 | `Utility/TwitchApiResult.cs`(新), `Utility/ChannelPointService.cs`, `Utility/TwitchHelper.cs`, `Dao/DAO_Setting.cs`, `Forms/ChannelPointRewardForm.cs`, `Panels/ChannelPointPanel.xaml(.cs)` | `d687645` | `dotnet build` 成功（0 エラー）。**実機動作は未検証** |
+| 2026-08-09 | P3-1〜8 | プリセット機能（モデル・マイグレーション・DAO・保存/適用・UI） | `Models/M_ChannelPoint.cs`(新), `Models/T_ChannelPointPreset*.cs`(新), `AppDbContext.cs`, `Migrations/`(新), `Dao/DAO_ChannelPoint*.cs`(新), `Forms/ChannelPointPresetForm.cs`(新), `Utility/ChannelPointService.cs`, `Panels/ChannelPointPanel.xaml(.cs)` | — | `dotnet build` 成功（0 エラー）。**実機動作は未検証** |
+| 2026-08-09 | P4-1〜8 | カテゴリ紐づけと自動適用 | `Forms/CategoryForm.cs`, `Panels/CategoryPanel.xaml(.cs)`, `Panels/PlayingGamePanel.xaml.cs`, `MainWindow.xaml.cs`, `Dao/DAO_Category.cs`, `Dao/DAO_ChannelPointPreset.cs` | — | `dotnet build` 成功（0 エラー）。**実機動作は未検証** |
 
 ## 4. 課題・保留
 
@@ -107,3 +129,7 @@ CP タブの初期化まで到達できず検証不能だったため、ユー�
 | 5 | 新規作成フォームは名前・コストのみのまま。Prompt・背景色・クールダウン等はコピー機能では引き継ぐが、手動作成時の入力欄は未実装 | 未対応（優先度低） |
 | 6 | `SettingName.UserName` は表示と Twitch ダッシュボード URL 用にのみ使う値になった（認証の前提条件ではなくなり、アクセストークンから毎回上書きされる） | 仕様変更として確定 |
 | 7 | `TwitchHelper.GetBroadcasterIdAsync(userName)` は起動経路からは呼ばれなくなったが、FriendPanel / ChatPanel が他ユーザーの情報取得に使っているため残す | 確認済み・残置 |
+| 8 | プリセットの内訳リストは表示専用。ON/OFF の編集は報酬一覧側で行い「上書き保存」する運用にした（同じ状態を 2 箇所で編集できると食い違うため） | 仕様として確定 |
+| 9 | `M_ChannelPoint`（報酬キャッシュ）は現状プリセット内訳の「削除済み」判定の補助のみで、実質は報酬一覧の取得結果から判定している。将来オフライン表示が必要になったら活用する | 用途限定 |
+| 10 | プリセット適用は差分のある報酬だけ PATCH する。報酬数が多い場合の Twitch レート制限は未検証 | 未検証 |
+| 11 | `dotnet-ef` 9.0.9 をグローバルツールとして導入した（マイグレーション生成に必要） | 環境構築として実施 |


### PR DESCRIPTION
## 概要

CP タブ（`ChannelPointPanel`）は作りかけのまま止まっており、実質使えない状態だった。
本 PR で「既存の不具合の修正」「Web 作成報酬のコピー」「プリセット機能」を入れ、実用可能な管理画面にする。

`develop` から分岐。作業記録は [`docs/CHANNELPOINT-SYSTEM-TASKS.md`](docs/CHANNELPOINT-SYSTEM-TASKS.md) に残してある。

## 背景（直した問題）

- **一覧が一度も読み込まれない** — `ReloadChannnelPoint()` の呼び出し元がパネル内部にしか無く、起動シーケンスにもタブ切替にも無かった。更新ボタンも無いため CP タブは常に空だった
- **Twitch の Web 画面から作成した報酬は OAuth アプリから操作できない**（Twitch 仕様：`client_id` が一致する報酬しか PATCH/DELETE できない）のに、それらも一覧に混ざり、トグルすると 403 で「切り替えに失敗しました」とだけ出て理由が分からなかった。`ChannelPointPanel.xaml` の `Header="操作可能"` 列は、まさにこれを出すために置かれたまま `DataTemplate` が空だった
- **プリセットが無い** — 「ゲーム参加可の配信では ABC を ON / EFG を OFF、アート配信ではその逆」を毎回手作業でやる必要があった
- **OAuth 認証直後にアプリがクラッシュする**（本 PR の動作確認中に発覚した既存バグ）

## 変更内容

### 1. 操作可否の判定と既存バグ修正

`only_manageable_rewards` を `true`/`false` の 2 回 GET し、**その差分で「このアプリから操作できるか」を判定**する（公式なフラグが存在しないため）。

- 「操作可能」列を実装（✔ / 🔒 ＋ ToolTip）。🔒 の行はトグルを無効化し、403 を踏ませない
- `Initialize()` を新設し `MainWindow_LoadedAsync` から呼ぶ ＋ 手動「更新」ボタン
- **バグ**: 一時停止トグルが `SelectedItem` 基準で、クリック行とズレると別の行を更新していた → `DataContext` 基準に統一
- **バグ**: 一時停止トグル後にキャッシュを更新せず古い状態を再表示していた
- **バグ**: `Mode=OneWay` の CheckBox はクリックでバインドが外れる（従来は毎回全件作り直していたため露見しなかった）→ TwoWay ＋ 失敗時ロールバック
- TwitchLib の `CustomReward` 直バインドをやめ、`ChannelPointRewardForm`（INPC）へ詰め替え

### 2. 報酬コピー

🔒 の報酬を、アプリ管理下の報酬として複製する。

- タイトルは接尾辞 `'` を付与（`SettingName.ChannelPointCopySuffix` で変更可）。45 文字上限で元を切り詰め、重複時は接尾辞を重ねて最大 3 回リトライ
- 画像以外の全項目（コスト / 説明 / 背景色 / 入力要否 / 上限 / クールダウン）を引き継ぎ
- 行単位のコピーと、チェックによる一括コピー
- コピー後に「画像は Web 画面で設定」「コピー元は Web 画面で削除」を案内し、Twitch の報酬設定ページを開くボタンを追加
- `TwitchApiResult` を追加し、403/400/401/429 等の**失敗理由を画面とログに出せる**ように（従来は例外を握り潰して null を返すだけだった）

### 3. プリセット（全件スナップショット方式）

- 操作可能な全報酬の `IsEnabled` をまとめて保存し、ワンクリックで復元
- 新規保存・上書き保存・名前変更・削除、選択中プリセットの内訳表示
- 適用時は現在の状態と突き合わせ、**差分のある報酬だけ** PATCH（レート制限対策）
- 削除済み / 操作不可になった報酬はスキップし件数を結果に含める

### 4. カテゴリ連動の自動適用

- カテゴリごとに適用するプリセットを紐づけ。**未紐づけなら何も変更しない**
- タイトル送信によるカテゴリ設定時と、プレイリストの「プレイ中」設定時に自動適用
- プリセット削除時はカテゴリからの紐づけも外し、存在しない ID が残らないように

### 5. OAuth 認証まわりの修正（計画外・動作確認の前提として実施）

動作確認で起動したところ認証直後に NullReferenceException で強制終了したため、合意のうえ本 PR に含めた。

- `OAuthButton_Click` が認証後に `StreamerDataSet()` を呼ぶだけで、起動時シーケンスがやっている「配信者 ID 取得」「`IgdbService.Initialize`」「各パネル初期化」を一切していなかった → `InitializeAfterAuthAsync` に共通化
- **Twitch ユーザー名の手入力を廃止**（`GetAuthenticatedUserAsync` でアクセストークンから本人を特定）
- `StreamerDataSet` の null 参照 2 箇所、`accessTokenResponse` / `deviceCodeResponse` の null チェック
- デバイスコード認証 URL に `user_code` としてログイン名を連結していた誤りを修正

## DB 変更

マイグレーション `20260809075615_channel_point_preset`

| 対象 | 内容 |
|---|---|
| `M_ChannelPoint`（新規） | 報酬キャッシュ |
| `T_ChannelPointPresetHeader`（新規） | プリセット |
| `T_ChannelPointPresetItem`（新規） | プリセットの中身（複合キー） |
| `M_Category` | `ChannelPointPresetId` 列を追加（nullable） |

既存 DB に対して適用済みであること、既存データが保持されることを実機で確認済み。

## レビュー時に見てほしい点

- `ChannelPointService.FetchRewardsAsync` の**操作可否判定**が本 PR の要。`only_manageable_rewards=true` が失敗した場合は「可否不明」なので、誤操作を防ぐため**安全側に倒して全件を操作不可**として表示する仕様にしている
- プリセット内訳リストは**表示専用**。ON/OFF の編集は報酬一覧側で行い「上書き保存」する運用にした（同じ状態を 2 箇所で編集できると食い違うため）
- プリセットアイテムの保存は「全削除 → 全追加」。`DAO_GamePlaylist.InsertUpdate(header, items)` に既存アイテム削除漏れによる重複バグがあるため、そちらは踏襲していない
- OAuth まわりは当初スコープ外だったが、直さないと動作確認自体ができなかった

## 動作確認状況

実機起動により確認できたこと：

- 異常終了なし（修正前は exit 82 / NRE）
- マイグレーション適用済み、既存データ保持
- `M_Setting.UserName` がトークンから自動設定 → **ユーザー名入力の廃止が機能**
- `M_ChannelPoint` に 29 件キャッシュ → **一覧取得が成功**（空だった問題は解消）

**未検証**：トグル / コピー / プリセット保存・適用 / カテゴリ連動。いずれも Twitch API を伴う操作のため、実際の画面操作での確認が必要。

### 要確認事項

実機で **29 件すべてが「操作不可」と判定された**。

1. 本当に全件が Web 画面から作成された（＝正常。コピー機能で解決）
2. `only_manageable_rewards=true` の呼び出しが失敗し安全側に倒れた（＝要修正）

この 2 つが同じ文言になっていたため、**区別できるようステータス表示を改善済み**（最終コミット）。次回起動時の表示で確定する。

なお、操作可能な報酬が 0 件の間はプリセットを保存できない（保存対象が操作可能な報酬に限られるため）。まずコピーが必要で、その旨を画面で案内している。

## コミット

| | |
|---|---|
| `3bc99c5` | 操作可否の判定と既存バグ修正 |
| `d687645` | 報酬コピー機能と OAuth 認証まわりの修正 |
| `ae8789e` | プリセット機能とカテゴリ連動の自動適用 |
| `0dbcef4` | 操作可否の判定失敗を画面で区別できるように |

🤖 Generated with [Claude Code](https://claude.com/claude-code)