### PR TITLE
カテゴリ選択が出来ないバグを修正し、サムネイルを表示出来るようにする

### DIFF
--- a/JTSA/Dao/DAO_Category.cs
+++ b/JTSA/Dao/DAO_Category.cs
@@ -78,12 +78,17 @@ namespace JTSA.Dao
         }
 
 
-        public static async Task<M_Category> InsertDataCreate(string categoryId, string steamUrl = "")
+        public static async Task<M_Category?> InsertDataCreate(string categoryId, string steamUrl = "")
         {
 
             var selectCategory = await TwitchHelper.GetCategoryByGameId(categoryId);
+            if (selectCategory == null) return null;
+
+            // Steamに無いカテゴリではappIdが取れないため、ヘッダー画像もnullになる
             var appId = SteamHelper.GetSteamAppId(steamUrl);
-            var steamHeaderArtUrl = await SteamHelper.GetSteamHeaderImageUrlAsync(appId);
+            var steamHeaderArtUrl = appId == null
+                ? null
+                : await SteamHelper.GetSteamHeaderImageUrlAsync(appId);
 
             return new M_Category
             {

--- a/JTSA/MainWindow.xaml.cs
+++ b/JTSA/MainWindow.xaml.cs
@@ -131,7 +131,22 @@ namespace JTSA
 		{
 			set
 			{
-				SelectCategoryBoxArt.Source = new BitmapImage(new Uri(value)); ;
+				// URLが無いカテゴリもあるため、空ならクリアするだけにする
+				if (string.IsNullOrWhiteSpace(value))
+				{
+					SelectCategoryBoxArt.Source = null;
+					return;
+				}
+
+				try
+				{
+					SelectCategoryBoxArt.Source = new BitmapImage(new Uri(value));
+				}
+				catch (Exception)
+				{
+					SelectCategoryBoxArt.Source = null;
+					AppLogPanel.Error(GetType().Name, $"ボックスアート表示失敗 「 {value} 」");
+				}
             }
 		}
 
@@ -192,12 +207,28 @@ namespace JTSA
             );
         }
 
+		/// <summary>
+		/// カテゴリIDからSteamのストアURLを引いて画面に反映する。
+		/// Art や Software and Game Development のような非ゲームカテゴリはSteamに存在しないため、
+		/// 取得できないことは異常ではない（その場合は空欄にする）。
+		/// </summary>
+		/// <param name="categoryId">カテゴリID</param>
 		private async void SteamUrlTextSet(string categoryId)
 		{
+			CurrentCategorySteamUrl = "";
 
-			var result = await IgdbService.GetSteamUrlsAsync(categoryId);
-			CurrentCategorySteamUrl = result[0];
+			if (string.IsNullOrWhiteSpace(categoryId)) return;
 
+			try
+			{
+				var result = await IgdbService.GetSteamUrlsAsync(categoryId);
+				CurrentCategorySteamUrl = result.FirstOrDefault() ?? "";
+			}
+			catch (Exception)
+			{
+				// async voidのため、ここで握らないと未処理例外でアプリが落ちる
+				AppLogPanel.Error(GetType().Name, $"SteamURL取得失敗 「 {categoryId} 」");
+			}
         }
 
 
@@ -575,7 +606,8 @@ namespace JTSA
             var title = CurrentTitleText;
 			var categoryId = SelectCategoryIdTextBlock.Text;
 			var categoryName = SelectCategoryNameTextBlock.Text;
-			var categoryBoxArtUrl = SelectCategoryBoxArt.Source.ToString();
+			// ボックスアートが無いカテゴリではSourceがnullになる
+			var categoryBoxArtUrl = SelectCategoryBoxArt.Source?.ToString() ?? "";
 
 
             using var client = new HttpClient();

--- a/JTSA/Panels/CategoryPanel.xaml.cs
+++ b/JTSA/Panels/CategoryPanel.xaml.cs
@@ -225,13 +225,12 @@ namespace JTSA.Panels
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private async void PlayCategoryAddButton_Click(object sender, RoutedEventArgs e)
+        private void PlayCategoryAddButton_Click(object sender, RoutedEventArgs e)
         {
-            // ボタンのDataContextから削除対象を取得
+            // ボタンのDataContextから追加対象を取得
             if ((sender as Button)?.DataContext is CategoryForm item)
             {
-                M_Category category = DAO_Category.SelectOneById(item.CategoryId);
-                await mainWindow.PlayingGamePanel.AddSteamImageAsync(item.CategoryId, category.SteamHeaderArtUrl);
+                mainWindow.PlayingGamePanel.AddPlaylistItem(item.CategoryId);
             }
 
             ReloadCategory();

--- a/JTSA/Panels/CategorySearchPanel.xaml.cs
+++ b/JTSA/Panels/CategorySearchPanel.xaml.cs
@@ -77,16 +77,18 @@ namespace JTSA.Panels
         {
             if (CategorySearchListBox.SelectedItem is CategoryForm selectedItem)
             {
+                // Steamに存在しないカテゴリ（Art等）ではURLが取れないため、空文字として扱う
                 List<string> steamUrls =  await IgdbService.GetSteamUrlsAsync(selectedItem.CategoryId);
 
-                string? steamUrl = steamUrls.FirstOrDefault();
+                string steamUrl = steamUrls.FirstOrDefault() ?? "";
 
                 // データ登録
-                var isnertData = await DAO_Category.InsertDataCreate(selectedItem.CategoryId, steamUrl + "/");
+                var isnertData = await DAO_Category.InsertDataCreate(selectedItem.CategoryId, steamUrl);
+                if (isnertData == null) return;
+
                 DAO_Category.Insert(isnertData);
 
-                M_Category category = DAO_Category.SelectOneById(selectedItem.CategoryId);
-                await mainWindow.PlayingGamePanel.AddSteamImageAsync(selectedItem.CategoryId, category.SteamHeaderArtUrl);
+                mainWindow.PlayingGamePanel.AddPlaylistItem(selectedItem.CategoryId);
 
                 CategorySearchTitleSerchTextBox.Text = "";
             }

--- a/JTSA/Panels/PlayingGamePanel.xaml.cs
+++ b/JTSA/Panels/PlayingGamePanel.xaml.cs
@@ -215,6 +215,48 @@ namespace JTSA.Panels
         #endregion
 
 
+        #region ==================== サムネイル ====================
+
+
+        /// <summary>
+        /// プレイリストに表示するサムネイルURLを決める。
+        /// 見栄えの良いSteamのヘッダー画像を優先し、Steamに無いカテゴリ（Art等）は
+        /// Twitchに登録されているボックスアートにフォールバックする。
+        /// </summary>
+        /// <param name="steamHeaderArtUrl">Steamのヘッダー画像URL（未取得ならnull）</param>
+        /// <param name="boxArtUrl">Twitchのボックスアート URL</param>
+        /// <returns>サムネイルURL。どちらも無ければ空文字</returns>
+        private static string ResolveThumbnailUrl(string? steamHeaderArtUrl, string? boxArtUrl)
+        {
+            if (!string.IsNullOrWhiteSpace(steamHeaderArtUrl)) return steamHeaderArtUrl;
+
+            // ボックスアートは縦長なのでタイル内では小さく表示される。解像度を確保するため大きめに要求する
+            return TwitchHelper.ResizeBoxArtUrl(boxArtUrl, 285, 380);
+        }
+
+
+        /// <summary>
+        /// カテゴリIDからサムネイルURLを解決する。DBに無ければTwitchから取り直す。
+        /// </summary>
+        /// <param name="categoryId">カテゴリID</param>
+        /// <returns>サムネイルURL。解決できなければ空文字</returns>
+        private static async Task<string> ResolveThumbnailUrlByCategoryIdAsync(string categoryId)
+        {
+            var categoryData = DAO_Category.SelectOneById(categoryId);
+
+            if (categoryData != null)
+            {
+                return ResolveThumbnailUrl(categoryData.SteamHeaderArtUrl, categoryData.BoxArtUrl);
+            }
+
+            var twitchCategoryData = await TwitchHelper.GetCategoryByGameId(categoryId);
+
+            return ResolveThumbnailUrl(null, twitchCategoryData?.BoxArtUrl);
+        }
+
+        #endregion
+
+
         #region ==================== DB関連メソッド ====================
 
 
@@ -258,7 +300,7 @@ namespace JTSA.Panels
             {
                 GamePlayListId = playlistId,
                 GamePlayListName = playlistTitleText,
-                ThumbnailCategoryUrl = playlistItemFormList.Count == 0 ? "" : playlistItemFormList[0].CategoryId,
+                ThumbnailCategoryUrl = playlistItemFormList.Count == 0 ? "" : playlistItemFormList[0].ImageUrl,
                 SelectedCount = 0,
                 SortNumber = 9999,
                 LastUsedDateTime = DateTime.Now,
@@ -309,11 +351,21 @@ namespace JTSA.Panels
 
             foreach (var gamePlayListHeader in gamePlayListHeaders)
             {
+                // 保存済みのThumbnailCategoryUrlには過去にカテゴリIDが入っている場合があるため、
+                // 先頭アイテムから毎回解決し直す
+                var firstItem = DAO_GamePlaylist
+                    .SelectGamePlaylistById(gamePlayListHeader.GamePlayListId)
+                    .FirstOrDefault();
+
+                var thumbnailUrl = firstItem == null
+                    ? ""
+                    : await ResolveThumbnailUrlByCategoryIdAsync(firstItem.CategoryId);
+
                 playlistHeaderFormList.Add(new PlaylistHeaderForm()
                 {
                     GamePlayListId = gamePlayListHeader.GamePlayListId,
                     GamePlayListName = gamePlayListHeader.GamePlayListName,
-                    ImageUrl = gamePlayListHeader.ThumbnailCategoryUrl,
+                    ImageUrl = thumbnailUrl,
                     LastUsedDate = gamePlayListHeader.LastUsedDateTime.ToString("yyyy/MM/dd hh:mm"),
                     IsLoaded = false
                 });
@@ -335,7 +387,7 @@ namespace JTSA.Panels
                 gamePlaylist = DAO_GamePlaylist.SelectHeaderById(CurrentGamePlaylistId);
             }
 
-            CurrentGamePlaylistName = gamePlaylist.GamePlayListName;
+            CurrentGamePlaylistName = gamePlaylist?.GamePlayListName ?? "";
 
         }
 
@@ -351,25 +403,13 @@ namespace JTSA.Panels
             // 画面に設定されているプレイリストIDに紐づくプレイリストアイテムを取得
             var gamePlayListItems = DAO_GamePlaylist.SelectGamePlaylistById(CurrentGamePlaylistId);
 
-            // 
+            //
             foreach (var game in gamePlayListItems)
             {
-                string imageUrl = "";
-                var categoryData = DAO_Category.SelectOneById(game.CategoryId);
-                if (categoryData == null)
-                {
-                    var twitchCategoryData = await TwitchHelper.GetCategoryByGameId(game.CategoryId);
-                    imageUrl = twitchCategoryData.BoxArtUrl;
-                }
-                else
-                {
-                    imageUrl = categoryData.SteamHeaderArtUrl != "" ? categoryData.SteamHeaderArtUrl : categoryData.BoxArtUrl;
-                }
-
                 playlistItemFormList.Add(new PlaylistItemForm()
                 {
                     CategoryId = game.CategoryId,
-                    ImageUrl = imageUrl,
+                    ImageUrl = await ResolveThumbnailUrlByCategoryIdAsync(game.CategoryId),
                     Status = (GameStatus)game.Status
                 });
             }
@@ -377,25 +417,12 @@ namespace JTSA.Panels
 
 
         /// <summary>
-        /// 
+        /// カテゴリを現在のプレイリストに追加する。
+        /// サムネイルは再読み込み時にカテゴリから解決するため、ここでは受け取らない。
         /// </summary>
-        /// <param name="urlText"></param>
-        /// <returns></returns>
-        public async Task AddSteamImageAsync(string categoryId, string urlText)
+        /// <param name="categoryId">追加するカテゴリID</param>
+        public void AddPlaylistItem(string categoryId)
         {
-            string url = "";
-            if (!string.IsNullOrEmpty(urlText)) { 
-                url = urlText.Trim();
-            }
-
-            var categoryData = await TwitchHelper.GetCategoryByGameId(categoryId);
-
-            playlistItemFormList.Add(new PlaylistItemForm
-            {
-                CategoryId = categoryId,
-                ImageUrl = string.IsNullOrEmpty(url) ? url : categoryData.BoxArtUrl,
-            });
-
             AddGamePlaylistItem(categoryId);
 
             ReloadGamePlaylistItem();

--- a/JTSA/Utility/SteamHelper.cs
+++ b/JTSA/Utility/SteamHelper.cs
@@ -18,22 +18,33 @@ namespace JTSA.Utility
             var apiUrl =
                 $"https://store.steampowered.com/api/appdetails?appids={appId}&cc=JP&l=japanese";
 
-            HttpClient httpClient = new();
-            var json = await httpClient.GetStringAsync(apiUrl);
+            // 通信失敗やレスポンス形式の想定外は「画像なし」として扱う。
+            // 呼び出し元はasync voidのイベントハンドラなので、ここで握らないとアプリが落ちる
+            try
+            {
+                HttpClient httpClient = new();
+                var json = await httpClient.GetStringAsync(apiUrl);
 
-            using var doc = JsonDocument.Parse(json);
+                using var doc = JsonDocument.Parse(json);
 
-            var root = doc.RootElement.GetProperty(appId);
+                if (!doc.RootElement.TryGetProperty(appId, out var root))
+                    return null;
 
-            if (!root.GetProperty("success").GetBoolean())
+                if (!root.TryGetProperty("success", out var success) || !success.GetBoolean())
+                    return null;
+
+                if (!root.TryGetProperty("data", out var data))
+                    return null;
+
+                if (data.TryGetProperty("header_image", out var headerImage))
+                    return headerImage.GetString();
+
                 return null;
-
-            var data = root.GetProperty("data");
-
-            if (data.TryGetProperty("header_image", out var headerImage))
-                return headerImage.GetString();
-
-            return null;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
 
 

--- a/JTSA/Utility/TwitchHelper.cs
+++ b/JTSA/Utility/TwitchHelper.cs
@@ -7,6 +7,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Windows;
 using TwitchLib.Api;
 using TwitchLib.Api.Helix.Models.ChannelPoints;
@@ -376,6 +377,27 @@ namespace JTSA.Utility
         #region ==================== カテゴリ取得関連 ====================
 
         /// <summary>
+        /// TwitchのボックスアートURLを指定サイズに整える。
+        /// Twitchは「...-{width}x{height}.jpg」というテンプレート形式で返すが、
+        /// DBには展開済み（-128x192.jpg）で保存されているものもあるため両方を受け付ける。
+        /// </summary>
+        /// <param name="boxArtUrl">ボックスアートURL</param>
+        /// <param name="width">横幅</param>
+        /// <param name="height">高さ</param>
+        /// <returns>サイズを差し替えたURL。URLが無ければ空文字</returns>
+        public static string ResizeBoxArtUrl(string? boxArtUrl, int width = 128, int height = 192)
+        {
+            if (string.IsNullOrWhiteSpace(boxArtUrl)) return "";
+
+            var url = boxArtUrl
+                .Replace("{width}", width.ToString())
+                .Replace("{height}", height.ToString());
+
+            return Regex.Replace(url, @"-\d+x\d+(\.\w+)$", $"-{width}x{height}$1");
+        }
+
+
+        /// <summary>
         /// カテゴリ検索
         /// </summary>
         /// <param name="categoryName"></param>
@@ -393,7 +415,8 @@ namespace JTSA.Utility
                     {
                         Id = responseItem.Id ?? "",
                         Name = responseItem.Name ?? "",
-                        BoxArtUrl = responseItem.BoxArtUrl ?? ""
+                        // 検索APIは{width}/{height}のテンプレートのまま返すので展開する
+                        BoxArtUrl = ResizeBoxArtUrl(responseItem.BoxArtUrl)
                     });
                 }
             }
@@ -417,18 +440,16 @@ namespace JTSA.Utility
             {
                 var apiResponse = await api.Helix.Games.GetGamesAsync(gameIds: [gameId]);
 
-                if (apiResponse?.Data != null)
-                {
-                    var responseData = apiResponse.Data.FirstOrDefault();
+                var responseData = apiResponse?.Data?.FirstOrDefault();
 
+                if (responseData != null)
+                {
                     result = new TwitchCategoryIF()
                     {
                         Id = responseData.Id,
                         Name = responseData.Name,
-                        BoxArtUrl = responseData.BoxArtUrl
+                        BoxArtUrl = ResizeBoxArtUrl(responseData.BoxArtUrl)
                     };
-
-                    result.BoxArtUrl = result.BoxArtUrl.Replace("{width}", "128").Replace("{height}", "192");
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## 概要

カテゴリを選ぶとアプリが落ちる不具合を修正し、Steam に無いカテゴリでも
プレイリストにサムネイルが表示されるようにしました。

## 修正内容

### 1. カテゴリ選択時のクラッシュ

`MainWindow.SteamUrlTextSet` が `IgdbService.GetSteamUrlsAsync` の結果を
`result[0]` で無防備に参照していたため、Steam に存在しないカテゴリ
（`Art` / `Software and Game Development` 等）で `ArgumentOutOfRangeException`
が発生していました。`async void` のため例外を誰も受け取れず、アプリごと停止します。

- `FirstOrDefault()` + try/catch に変更
- 同経路で落ちる `CurrentCategoryBoxArtUrl` セッター（空URLで `new Uri()` が例外）にガードを追加
- Steam API 呼び出し（`SteamHelper`）の通信失敗・想定外レスポンスも「画像なし」として扱うように

### 2. プレイリストの画像が表示されない

Steam ヘッダー画像が無いときに Twitch のボックスアートへフォールバックする処理が
3 箇所とも壊れていました。

| 箇所 | 内容 |
|---|---|
| `ReloadGamePlaylistItem` | `SteamHeaderArtUrl != ""` で判定していたが実際の値は `null`。フォールバックが効いていなかった |
| `AddSteamImageAsync` | 三項演算子が逆（Steam URL がある時に BoxArt を使っていた） |
| `FormConvertToPlaylistHeader` | `ThumbnailCategoryUrl` に URL ではなくカテゴリ ID を保存していた |

`ResolveThumbnailUrl` / `ResolveThumbnailUrlByCategoryIdAsync` に解決処理を一本化しました。
プレイリスト一覧のサムネイルは保存値に頼らず毎回解決するため、既存データも自動で回復します。

### 3. カテゴリ検索リストの画像

`SearchCategoriesByGameNameAsync` がボックスアート URL の `{width}`/`{height}` を
展開していなかったため画像が出ていませんでした。`TwitchHelper.ResizeBoxArtUrl` を
追加して置換処理を集約しています。

## その他

- `AddSteamImageAsync(categoryId, url)` は引数の URL が実質使われていなかったため
  `AddPlaylistItem(categoryId)` に整理し、呼び出し側 2 箇所を追従
- DB スキーマ変更・XAML 変更なし（マイグレーション不要）

## 動作確認

- `Art` / `Software and Game Development` を選択してもクラッシュしない
- Steam があるゲームは従来どおり Steam URL / ヘッダー画像が表示される
- プレイリストのタイル・一覧サムネイル・OBS オーバーレイで画像が表示される
- カテゴリ検索リストのボックスアートが表示される